### PR TITLE
Expose generic DNSBL integration bridge for WordPress addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the DNSBL plugin should be documented in this file.
 
+## 3.1.6 - 2026-08-19
+
+### Added
+- Added the `tornevall_dnsbl_capabilities`, `tornevall_dnsbl_check_ip`, and `tornevall_dnsbl_report_ip` plugin-to-plugin filters so other Tornevall WordPress plugins can use DNSBL as an optional addon without coupling to internal classes.
+- Added an explicit guestbook/web-abuse report path that defaults to `IP_ABUSE_NO_SMTP` (64) and reuses the configured DNSBL/Tools token permissions.
+
+### Security
+- The integration bridge never exposes the DNSBL token to consuming JavaScript or public markup.
+- Blacklist publication is never automatic through the addon bridge; the report filter requires a WordPress administrator and a DNSBL token with add permission.
+
 ## 3.1.5 - 2026-07-05
 
 ### Fixed
@@ -33,7 +43,7 @@ All notable changes to the DNSBL plugin should be documented in this file.
 - Removal-page Turnstile reuses the existing comment Turnstile site key, secret key, and theme when admins opt in, so the hotfix stays small and does not introduce a second key-management workflow.
 
 ### Fixed
-- Site owners can now disable Turnstile only on the public delisting/removal flow when `challenges.cloudflare.com` is unstable, without having to weaken comment or WordPress registration protection at the same time.
+- Site owners can now disable Turnstile only on the public delisting/removal flow when `challenges.cloudflare.com` is unstable, without having to weaken comment or registration protection at the same time.
 
 ## 3.1.0
 
@@ -255,7 +265,6 @@ All notable changes to the DNSBL plugin should be documented in this file.
 
 ### Added
 - Initial plugin release (`TSDWP-9`, `TSDWP-5`).
-- Added the admin control panel.
 - Added host detection on bitmask level.
 
 ## Historical source trail

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WordPress plugin for DNSBL/FraudBL-based protection of comments, registrations a
 
 ## Release metadata
 
-- **Release:** `3.1.5`
+- **Release:** `3.1.6`
 - **Requires at least:** `5.8`
 - **Requires PHP:** `8.1`
 - **Tested up to:** `7.0`
@@ -38,12 +38,40 @@ The current release line includes:
 - an extra removal-page Turnstile fail-open checkbox so the public delist flow can temporarily bypass the Turnstile challenge automatically when the widget or Cloudflare verification path has operational problems
 - AJAX proxy flow for DNSBL writes through WordPress backend, plus dry-run controls for both local simulation and API acknowledgement (`dry_run`)
 - additive site identity stamping on Tools DNSBL write/check requests (`source_type`, `source_name`, `source_site_url`, `source_site_host`) so backend delist audits can show which WordPress site submitted the request
+- a stable plugin-to-plugin integration bridge for optional Tornevall add-ons, with capability discovery, IP checking and explicit administrator-approved abuse reporting
 - a dismissible admin reminder that invites site owners to leave WordPress.org feedback when the plugin is helping them
 - the default protection profile still includes `IP_FRAUDCOMMERCE`, and public removal references continue to point at <https://www.tornevall.net/removal/>
 
 FraudBL and fraud-related discovery are intentionally kept visible in the project description even though the plugin title now aligns more closely with the slug and package identity.
 
-WooCommerce-oriented protection is a planned next step, but it is not part of the packaged `3.1.5` release yet.
+WooCommerce-oriented protection is a planned next step, but it is not part of the packaged `3.1.6` release yet.
+
+## Plugin-to-plugin integration
+
+DNSBL remains optional for consuming plugins. Tornevall Tools for WordPress can therefore operate its guestbook without this plugin, while activating DNSBL adds visitor-IP filtering and explicit abuse-report controls.
+
+The stable WordPress filters are:
+
+```php
+$capabilities = apply_filters('tornevall_dnsbl_capabilities', null, [
+    'consumer' => 'my-plugin',
+]);
+
+$check = apply_filters('tornevall_dnsbl_check_ip', null, '203.0.113.10', [
+    'consumer' => 'my-plugin',
+]);
+
+$report = apply_filters('tornevall_dnsbl_report_ip', null, '203.0.113.10', [
+    'bitmask' => 64,
+    'source_note' => 'Explicit administrator abuse report.',
+], [
+    'consumer' => 'my-plugin',
+]);
+```
+
+`tornevall_dnsbl_report_ip` requires a logged-in WordPress administrator and a configured DNSBL token with add permission. The integration bridge never auto-reports a visitor and never exposes the configured token to browser JavaScript.
+
+For guestbook/web-form abuse, bitmask `64` (`IP_ABUSE_NO_SMTP`) is the default classification.
 
 ## Description
 
@@ -124,6 +152,12 @@ Use the safe IP whitelist and the frontend dry-run support for administrators. W
 ## Changelog
 
 See [`CHANGELOG.md`](./CHANGELOG.md) for the complete version series from `1.0.0` onward.
+
+### 3.1.6 highlights
+
+- Added an optional, stable plugin-to-plugin integration bridge for DNSBL capability discovery, checks and explicit abuse reports
+- Guestbook/web abuse uses bitmask 64 by default
+- Blacklist publication through the bridge remains administrator-triggered and permission-aware
 
 ### 3.1.5 highlights
 

--- a/includes/class-dnsbl-integration.php
+++ b/includes/class-dnsbl-integration.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Tornevall\Networks\DNSBL;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Stable plugin-to-plugin integration surface for Tornevall WordPress addons.
+ *
+ * Consumers use WordPress filters instead of reaching into DNSBL internals:
+ * - tornevall_dnsbl_capabilities
+ * - tornevall_dnsbl_check_ip
+ * - tornevall_dnsbl_report_ip
+ */
+class Integration
+{
+    public const DEFAULT_GUESTBOOK_BITMASK = 64;
+
+    public static function registerHooks(): void
+    {
+        add_filter('tornevall_dnsbl_capabilities', [self::class, 'capabilities'], 10, 2);
+        add_filter('tornevall_dnsbl_check_ip', [self::class, 'checkIp'], 10, 3);
+        add_filter('tornevall_dnsbl_report_ip', [self::class, 'reportIp'], 10, 4);
+    }
+
+    /**
+     * @param mixed $current Existing capability payload from another provider.
+     * @param mixed $context Optional consumer context.
+     * @return array<string,mixed>
+     */
+    public static function capabilities($current = null, $context = []): array
+    {
+        $client = ApiClient::fromPluginOptions();
+        if (!$client instanceof ApiClient) {
+            return [
+                'provider' => 'tornevall-wp-dnsbl',
+                'installed' => true,
+                'configured' => false,
+                'can_check' => false,
+                'can_report' => false,
+                'message' => __('DNSBL is installed, but no DNSBL / Tools API token is configured.', 'tornevall-networks-dnsbl-implementation'),
+            ];
+        }
+
+        $permissions = $client->getTokenPermissionSummary();
+
+        return [
+            'provider' => 'tornevall-wp-dnsbl',
+            'installed' => true,
+            'configured' => true,
+            'can_check' => true,
+            'can_report' => !empty($permissions['is_active']) && !empty($permissions['can_add']),
+            'message' => trim((string)($permissions['message'] ?? '')),
+            'permissions' => [
+                'is_active' => !empty($permissions['is_active']),
+                'can_add' => !empty($permissions['can_add']),
+                'can_delete' => !empty($permissions['can_delete']),
+            ],
+        ];
+    }
+
+    /**
+     * @param mixed $current Existing result from another integration provider.
+     * @param mixed $ip IP address to inspect.
+     * @param mixed $context Optional consumer context.
+     * @return array<string,mixed>
+     */
+    public static function checkIp($current, $ip, $context = []): array
+    {
+        $ip = trim((string)$ip);
+        if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+            return self::errorResult('invalid_ip', __('A valid IP address is required.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        $client = ApiClient::fromPluginOptions();
+        if (!$client instanceof ApiClient) {
+            return self::errorResult('not_configured', __('DNSBL is installed, but no DNSBL / Tools API token is configured.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        $result = $client->checkIp($ip);
+        $body = is_array($result['body'] ?? null) ? $result['body'] : [];
+        $bitmask = self::extractBitmask($body);
+        $listed = self::extractListed($body, $bitmask);
+
+        return [
+            'provider' => 'tornevall-wp-dnsbl',
+            'available' => true,
+            'ok' => !empty($result['ok']),
+            'status' => (int)($result['status'] ?? 0),
+            'ip' => $ip,
+            'listed' => $listed,
+            'bitmask' => $bitmask,
+            'message' => self::resultMessage($result, $listed),
+            'error' => trim((string)($result['error'] ?? '')),
+        ];
+    }
+
+    /**
+     * Explicitly report one abusive IP through the configured DNSBL write API.
+     * This method never runs automatically from a content rejection hook.
+     *
+     * @param mixed $current Existing result from another integration provider.
+     * @param mixed $ip IP address to report.
+     * @param mixed $options Report options.
+     * @param mixed $context Optional consumer context.
+     * @return array<string,mixed>
+     */
+    public static function reportIp($current, $ip, $options = [], $context = []): array
+    {
+        if (!current_user_can('manage_options')) {
+            return self::errorResult('forbidden', __('Administrator permission is required to report an IP address.', 'tornevall-networks-dnsbl-implementation'), 403);
+        }
+
+        $ip = trim((string)$ip);
+        if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+            return self::errorResult('invalid_ip', __('A valid IP address is required.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        $client = ApiClient::fromPluginOptions();
+        if (!$client instanceof ApiClient) {
+            return self::errorResult('not_configured', __('DNSBL is installed, but no DNSBL / Tools API token is configured.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        $permissions = $client->getTokenPermissionSummary();
+        if (empty($permissions['is_active']) || empty($permissions['can_add'])) {
+            return self::errorResult(
+                'report_not_permitted',
+                trim((string)($permissions['message'] ?? '')) ?: __('The configured DNSBL token cannot add blacklist records.', 'tornevall-networks-dnsbl-implementation'),
+                403
+            );
+        }
+
+        $options = is_array($options) ? $options : [];
+        $bitmask = isset($options['bitmask']) ? (int)$options['bitmask'] : self::DEFAULT_GUESTBOOK_BITMASK;
+        $bitmask = max(0, min(255, $bitmask)) & ~1;
+        if ($bitmask === 0) {
+            $bitmask = self::DEFAULT_GUESTBOOK_BITMASK;
+        }
+
+        $publicationType = strtolower(trim((string)($options['publication_type'] ?? 'dnsbl')));
+        if (!in_array($publicationType, ['dnsbl', 'fraudbl', 'commerce'], true)) {
+            $publicationType = 'dnsbl';
+        }
+
+        $sourceNote = sanitize_text_field((string)($options['source_note'] ?? 'Guestbook abuse reported by a WordPress administrator.'));
+        $result = $client->addIp($ip, $bitmask, $publicationType, 300, [
+            'dry_run' => !empty($options['dry_run']),
+            'source_note' => $sourceNote,
+            'source_type' => 'wordpress_guestbook',
+        ]);
+
+        return [
+            'provider' => 'tornevall-wp-dnsbl',
+            'available' => true,
+            'ok' => !empty($result['ok']),
+            'status' => (int)($result['status'] ?? 0),
+            'ip' => $ip,
+            'bitmask' => $bitmask,
+            'publication_type' => $publicationType,
+            'message' => self::resultMessage($result, null),
+            'error' => trim((string)($result['error'] ?? '')),
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $body
+     */
+    private static function extractBitmask(array $body): ?int
+    {
+        foreach (['bitmask', 'combined_bitmask', 'reputation'] as $key) {
+            if (isset($body[$key]) && is_numeric($body[$key])) {
+                return (int)$body[$key];
+            }
+        }
+
+        foreach (['result', 'lookup', 'data', 'summary'] as $key) {
+            if (isset($body[$key]) && is_array($body[$key])) {
+                $nested = self::extractBitmask($body[$key]);
+                if ($nested !== null) {
+                    return $nested;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $body
+     */
+    private static function extractListed(array $body, ?int $bitmask): ?bool
+    {
+        foreach (['listed', 'is_listed'] as $key) {
+            if (array_key_exists($key, $body)) {
+                return (bool)$body[$key];
+            }
+        }
+
+        if ($bitmask !== null) {
+            return $bitmask > 0;
+        }
+
+        foreach (['result', 'lookup', 'data', 'summary'] as $key) {
+            if (isset($body[$key]) && is_array($body[$key])) {
+                $nested = self::extractListed($body[$key], self::extractBitmask($body[$key]));
+                if ($nested !== null) {
+                    return $nested;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $result
+     */
+    private static function resultMessage(array $result, ?bool $listed): string
+    {
+        $body = is_array($result['body'] ?? null) ? $result['body'] : [];
+        $message = trim((string)($body['message'] ?? $body['reason'] ?? $result['error'] ?? ''));
+        if ($message !== '') {
+            return $message;
+        }
+
+        if ($listed === true) {
+            return __('The IP address is currently listed.', 'tornevall-networks-dnsbl-implementation');
+        }
+        if ($listed === false) {
+            return __('The IP address is not currently listed.', 'tornevall-networks-dnsbl-implementation');
+        }
+
+        return !empty($result['ok'])
+            ? __('DNSBL request completed.', 'tornevall-networks-dnsbl-implementation')
+            : __('DNSBL request failed.', 'tornevall-networks-dnsbl-implementation');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function errorResult(string $reason, string $message, int $status = 400): array
+    {
+        return [
+            'provider' => 'tornevall-wp-dnsbl',
+            'available' => true,
+            'ok' => false,
+            'status' => $status,
+            'reason' => $reason,
+            'message' => $message,
+            'error' => $message,
+        ];
+    }
+}

--- a/includes/class-dnsbl-integration.php
+++ b/includes/class-dnsbl-integration.php
@@ -7,16 +7,20 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Stable plugin-to-plugin integration surface for Tornevall WordPress addons.
+ * Stable plugin-to-plugin integration surface for optional WordPress consumers.
  *
- * Consumers use WordPress filters instead of reaching into DNSBL internals:
+ * The hooks are intentionally generic. Guestbooks, comments, Akismet adapters,
+ * registration flows and future plugins can all use the same bridge without
+ * reaching into DNSBL plugin internals.
+ *
  * - tornevall_dnsbl_capabilities
  * - tornevall_dnsbl_check_ip
  * - tornevall_dnsbl_report_ip
  */
 class Integration
 {
-    public const DEFAULT_GUESTBOOK_BITMASK = 64;
+    public const DEFAULT_WEB_ABUSE_BITMASK = 64;
+    public const DEFAULT_GUESTBOOK_BITMASK = self::DEFAULT_WEB_ABUSE_BITMASK;
 
     public static function registerHooks(): void
     {
@@ -58,6 +62,7 @@ class Integration
                 'can_add' => !empty($permissions['can_add']),
                 'can_delete' => !empty($permissions['can_delete']),
             ],
+            'context' => is_array($context) ? $context : [],
         ];
     }
 
@@ -94,12 +99,14 @@ class Integration
             'bitmask' => $bitmask,
             'message' => self::resultMessage($result, $listed),
             'error' => trim((string)($result['error'] ?? '')),
+            'context' => is_array($context) ? $context : [],
         ];
     }
 
     /**
      * Explicitly report one abusive IP through the configured DNSBL write API.
-     * This method never runs automatically from a content rejection hook.
+     * The bridge never reports automatically merely because another plugin
+     * rejected content or classified it as spam.
      *
      * @param mixed $current Existing result from another integration provider.
      * @param mixed $ip IP address to report.
@@ -133,22 +140,41 @@ class Integration
         }
 
         $options = is_array($options) ? $options : [];
-        $bitmask = isset($options['bitmask']) ? (int)$options['bitmask'] : self::DEFAULT_GUESTBOOK_BITMASK;
-        $bitmask = max(0, min(255, $bitmask)) & ~1;
-        if ($bitmask === 0) {
-            $bitmask = self::DEFAULT_GUESTBOOK_BITMASK;
+        $context = is_array($context) ? $context : [];
+        $requestedBitmask = isset($options['bitmask']) ? (int)$options['bitmask'] : self::DEFAULT_WEB_ABUSE_BITMASK;
+        $requestedBitmask = max(0, min(255, $requestedBitmask)) & ~1;
+        if ($requestedBitmask === 0) {
+            $requestedBitmask = self::DEFAULT_WEB_ABUSE_BITMASK;
         }
+
+        $check = self::checkIp(null, $ip, $context);
+        $currentBitmask = !empty($check['ok']) && is_numeric($check['bitmask'] ?? null)
+            ? (int)$check['bitmask']
+            : 0;
+        $bitmask = ($currentBitmask | $requestedBitmask) & ~1;
 
         $publicationType = strtolower(trim((string)($options['publication_type'] ?? 'dnsbl')));
         if (!in_array($publicationType, ['dnsbl', 'fraudbl', 'commerce'], true)) {
             $publicationType = 'dnsbl';
         }
 
-        $sourceNote = sanitize_text_field((string)($options['source_note'] ?? 'Guestbook abuse reported by a WordPress administrator.'));
-        $result = $client->addIp($ip, $bitmask, $publicationType, 300, [
+        $sourceType = sanitize_key((string)($options['source_type'] ?? $context['source_type'] ?? $context['feature'] ?? 'wordpress'));
+        $sourceName = sanitize_text_field((string)($options['source_name'] ?? $context['source_name'] ?? $context['consumer'] ?? 'wordpress'));
+        $sourceNote = sanitize_text_field((string)($options['source_note'] ?? 'WordPress abuse report.'));
+        $siteUrl = function_exists('home_url') ? trim((string)home_url('/')) : '';
+        $siteHost = $siteUrl !== '' ? trim((string)wp_parse_url($siteUrl, PHP_URL_HOST)) : '';
+
+        $result = self::publishReport([
+            'ip' => $ip,
+            'bitmask' => $bitmask,
+            'publication_type' => $publicationType,
+            'ttl' => 300,
             'dry_run' => !empty($options['dry_run']),
-            'source_note' => $sourceNote,
-            'source_type' => 'wordpress_guestbook',
+            'source_type' => $sourceType !== '' ? $sourceType : 'wordpress',
+            'source_name' => $sourceName !== '' ? $sourceName : $siteHost,
+            'source_note' => $sourceNote !== '' ? $sourceNote : 'WordPress abuse report.',
+            'source_site_url' => $siteUrl,
+            'source_site_host' => $siteHost,
         ]);
 
         return [
@@ -159,8 +185,75 @@ class Integration
             'ip' => $ip,
             'bitmask' => $bitmask,
             'publication_type' => $publicationType,
+            'source_type' => $sourceType,
+            'source_name' => $sourceName,
+            'source_note' => $sourceNote,
             'message' => self::resultMessage($result, null),
             'error' => trim((string)($result['error'] ?? '')),
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * Send the explicit report with its source metadata so Tools can publish the
+     * corresponding TXT record. This path is only reachable after the DNSBL
+     * plugin has verified that its configured token is active and can add.
+     *
+     * @param array<string,mixed> $payload
+     * @return array{ok:bool,status:int,body:array,error:string|null}
+     */
+    private static function publishReport(array $payload): array
+    {
+        $token = trim((string)Plugin::apiToken());
+        $baseUrl = untrailingslashit(rtrim((string)Plugin::toolsBaseUrl(), '/'));
+        if ($token === '' || $baseUrl === '') {
+            return [
+                'ok' => false,
+                'status' => 0,
+                'body' => [],
+                'error' => __('DNSBL is not configured.', 'tornevall-networks-dnsbl-implementation'),
+            ];
+        }
+
+        $response = wp_remote_request($baseUrl . '/api/dnsbl/records/add', [
+            'method' => 'POST',
+            'timeout' => 45,
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'X-Dnsbl-Token' => $token,
+            ],
+            'body' => wp_json_encode(array_filter($payload, static function ($value): bool {
+                return $value !== null && $value !== '' && $value !== false;
+            })),
+        ]);
+
+        if (is_wp_error($response)) {
+            return [
+                'ok' => false,
+                'status' => 0,
+                'body' => [],
+                'error' => $response->get_error_message(),
+            ];
+        }
+
+        $status = (int)wp_remote_retrieve_response_code($response);
+        $rawBody = (string)wp_remote_retrieve_body($response);
+        $body = json_decode($rawBody, true);
+        $body = is_array($body) ? $body : ['raw' => $rawBody];
+        $error = null;
+        if ($status < 200 || $status >= 300) {
+            $error = trim((string)($body['message'] ?? $body['reason'] ?? ''));
+            if ($error === '') {
+                $error = 'HTTP ' . $status;
+            }
+        }
+
+        return [
+            'ok' => $status >= 200 && $status < 300,
+            'status' => $status,
+            'body' => $body,
+            'error' => $error,
         ];
     }
 

--- a/includes/class-dnsbl-integration.php
+++ b/includes/class-dnsbl-integration.php
@@ -44,11 +44,14 @@ class Integration
                 'configured' => false,
                 'can_check' => false,
                 'can_report' => false,
+                'can_custom_txt' => false,
                 'message' => __('DNSBL is installed, but no DNSBL / Tools API token is configured.', 'tornevall-networks-dnsbl-implementation'),
             ];
         }
 
         $permissions = $client->getTokenPermissionSummary();
+        $token = is_array($permissions['token'] ?? null) ? $permissions['token'] : [];
+        $canCustomTxt = !empty($token['can_custom_txt']) || !empty($token['is_admin_token']);
 
         return [
             'provider' => 'tornevall-wp-dnsbl',
@@ -56,11 +59,13 @@ class Integration
             'configured' => true,
             'can_check' => true,
             'can_report' => !empty($permissions['is_active']) && !empty($permissions['can_add']),
+            'can_custom_txt' => $canCustomTxt,
             'message' => trim((string)($permissions['message'] ?? '')),
             'permissions' => [
                 'is_active' => !empty($permissions['is_active']),
                 'can_add' => !empty($permissions['can_add']),
                 'can_delete' => !empty($permissions['can_delete']),
+                'can_custom_txt' => $canCustomTxt,
             ],
             'context' => is_array($context) ? $context : [],
         ];
@@ -139,6 +144,8 @@ class Integration
             );
         }
 
+        $token = is_array($permissions['token'] ?? null) ? $permissions['token'] : [];
+        $canCustomTxt = !empty($token['can_custom_txt']) || !empty($token['is_admin_token']);
         $options = is_array($options) ? $options : [];
         $context = is_array($context) ? $context : [];
         $requestedBitmask = isset($options['bitmask']) ? (int)$options['bitmask'] : self::DEFAULT_WEB_ABUSE_BITMASK;
@@ -153,6 +160,23 @@ class Integration
             : 0;
         $bitmask = ($currentBitmask | $requestedBitmask) & ~1;
 
+        if ($currentBitmask > 0 && $bitmask === $currentBitmask) {
+            return [
+                'provider' => 'tornevall-wp-dnsbl',
+                'available' => true,
+                'ok' => true,
+                'status' => 200,
+                'ip' => $ip,
+                'bitmask' => $bitmask,
+                'already_classified' => true,
+                'can_custom_txt' => $canCustomTxt,
+                'txt_metadata_published' => false,
+                'message' => __('The IP address already contains the requested DNSBL classification, so no duplicate DNS write was submitted.', 'tornevall-networks-dnsbl-implementation'),
+                'error' => '',
+                'context' => $context,
+            ];
+        }
+
         $publicationType = strtolower(trim((string)($options['publication_type'] ?? 'dnsbl')));
         if (!in_array($publicationType, ['dnsbl', 'fraudbl', 'commerce'], true)) {
             $publicationType = 'dnsbl';
@@ -164,7 +188,7 @@ class Integration
         $siteUrl = function_exists('home_url') ? trim((string)home_url('/')) : '';
         $siteHost = $siteUrl !== '' ? trim((string)wp_parse_url($siteUrl, PHP_URL_HOST)) : '';
 
-        $result = self::publishReport([
+        $payload = [
             'ip' => $ip,
             'bitmask' => $bitmask,
             'publication_type' => $publicationType,
@@ -172,10 +196,17 @@ class Integration
             'dry_run' => !empty($options['dry_run']),
             'source_type' => $sourceType !== '' ? $sourceType : 'wordpress',
             'source_name' => $sourceName !== '' ? $sourceName : $siteHost,
-            'source_note' => $sourceNote !== '' ? $sourceNote : 'WordPress abuse report.',
             'source_site_url' => $siteUrl,
             'source_site_host' => $siteHost,
-        ]);
+        ];
+
+        // Tools has a separate delegated permission for caller-defined TXT data.
+        // Do not make an otherwise valid add fail merely because the token lacks it.
+        if ($canCustomTxt && $sourceNote !== '') {
+            $payload['source_note'] = $sourceNote;
+        }
+
+        $result = self::publishReport($payload);
 
         return [
             'provider' => 'tornevall-wp-dnsbl',
@@ -187,7 +218,9 @@ class Integration
             'publication_type' => $publicationType,
             'source_type' => $sourceType,
             'source_name' => $sourceName,
-            'source_note' => $sourceNote,
+            'source_note' => $canCustomTxt ? $sourceNote : '',
+            'can_custom_txt' => $canCustomTxt,
+            'txt_metadata_published' => $canCustomTxt && !empty($result['ok']),
             'message' => self::resultMessage($result, null),
             'error' => trim((string)($result['error'] ?? '')),
             'context' => $context,
@@ -195,9 +228,9 @@ class Integration
     }
 
     /**
-     * Send the explicit report with its source metadata so Tools can publish the
-     * corresponding TXT record. This path is only reachable after the DNSBL
-     * plugin has verified that its configured token is active and can add.
+     * Send an explicit report through the configured DNSBL write API. Caller-
+     * supplied source_note is included only when token-info confirms that the
+     * delegated token may use custom TXT metadata.
      *
      * @param array<string,mixed> $payload
      * @return array{ok:bool,status:int,body:array,error:string|null}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: antispam, blacklist, fraud, comment spam, user registration
 Requires at least: 5.8
 Requires PHP: 8.1
 Tested up to: 7.0
-Stable tag: 3.1.5
+Stable tag: 3.1.6
 License: GPLv2 or later
 
 Tornevall Networks DNSBL implementation with FraudBL support for WordPress
@@ -14,6 +14,8 @@ Tornevall Networks DNSBL implementation with FraudBL support for WordPress
 Protect your WordPress site against comment spam, abusive registrations, and other unwanted submissions with Tornevall Networks DNSBL and FraudBL.
 
 The plugin is built to give site owners a practical anti-abuse layer without turning everyday moderation into a maintenance project..
+
+Other Tornevall WordPress plugins can use the optional plugin-to-plugin integration filters to check visitor IP addresses and, when the configured DNSBL token permits it, perform an explicit administrator-approved abuse report. Installing this plugin is not required for those other plugins to function.
 
 Report issues and feedback: [GitHub issues](https://github.com/Tornevall/tornevall-wp-dnsbl/issues)
 Plugin URL: [WordPress.org plugin page](https://wordpress.org/plugins/tornevall-networks-dnsbl-implementation/)
@@ -54,6 +56,10 @@ Yes. You can host the built-in form on any page with:
 
 But you need permissions for this, which can be gained by request via [https://tools.tornevall.net/](https://tools.tornevall.net/).
 
+* Does another Tornevall plugin need DNSBL to work?
+
+No. DNSBL is an optional protection add-on. A consumer such as Tornevall Tools for WordPress can continue without it. When DNSBL is active, the consumer can discover whether IP checking and explicit abuse reporting are available through the plugin integration filters.
+
 
 == Screenshots ==
 
@@ -73,6 +79,13 @@ But you need permissions for this, which can be gained by request via [https://t
 
 
 == Changelog ==
+
+= 3.1.6 =
+
+* Added a stable plugin-to-plugin DNSBL integration bridge for optional Tornevall WordPress add-ons.
+* Consumers can discover check/report capability, check a visitor IP and explicitly report web/guestbook abuse without reading DNSBL plugin internals.
+* Guestbook/web abuse reports default to `IP_ABUSE_NO_SMTP` (64).
+* Abuse publication is never triggered automatically by the integration bridge; reporting requires an administrator action and a DNSBL token with add permission.
 
 = 3.1.5 =
 
@@ -116,6 +129,10 @@ But you need permissions for this, which can be gained by request via [https://t
 * The admin UI now also shows a dismissible reminder that links directly to the WordPress.org review form for quick feedback.
 
 == Upgrade Notice ==
+
+= 3.1.6 =
+
+Adds the optional DNSBL integration bridge used by Tornevall Tools for WordPress and future add-ons. Existing comment, registration and delisting behavior remains unchanged.
 
 = 3.1.5 =
 

--- a/tornevall-wp-dnsbl.php
+++ b/tornevall-wp-dnsbl.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/tornevall-networks-dnsbl-implementation/
  * Project URI: https://github.com/Tornevall/tornevall-wp-dnsbl
  * Description: DNSBL and FraudBL protection for comments and WordPress registrations, with Cloudflare Turnstile support, whitelist-based dry runs, and admin-safe blocking controls.
- * Version: 3.1.5
+ * Version: 3.1.6
  * Author: Thomas Tornevall
  * Author URI: https://www.tornevalls.se/
  * Text Domain: tornevall-networks-dnsbl-implementation
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
 define('TORNEVALL_DNSBL_PLUGIN_FILE', __FILE__);
 define('TORNEVALL_DNSBL_PLUGIN_DIR', plugin_dir_path(TORNEVALL_DNSBL_PLUGIN_FILE));
 define('TORNEVALL_DNSBL_PLUGIN_URL', plugin_dir_url(TORNEVALL_DNSBL_PLUGIN_FILE));
-define('TORNEVALL_DNSBL_PLUGIN_VERSION', '3.1.5');
+define('TORNEVALL_DNSBL_PLUGIN_VERSION', '3.1.6');
 define('TORNEVALL_DNSBL_PUBLIC_DOCS_URL', 'https://tools.tornevall.net/docs/dnsbl-api');
 define('TORNEVALL_DNSBL_CHANGELOG_URL', 'https://github.com/Tornevall/tornevall-wp-dnsbl/blob/master/CHANGELOG.md');
 define('TORNEVALL_DNSBL_HISTORY_URL', 'https://github.com/Tornevall/tornevall-wp-dnsbl/commits/master');
@@ -29,6 +29,7 @@ foreach ([
     'includes/class-dnsbl-admin.php',
     'includes/class-dnsbl-api-client.php',
     'includes/class-dnsbl-write-queue.php',
+    'includes/class-dnsbl-integration.php',
     'includes/dnsbl-utils.php',
     'includes/dnsbl-migrations.php',
     'includes/dnsbl-bootstrap.php',
@@ -47,3 +48,4 @@ register_deactivation_hook(TORNEVALL_DNSBL_PLUGIN_FILE, 'tornevall_wp_dnsbl_deac
 register_uninstall_hook(TORNEVALL_DNSBL_PLUGIN_FILE, 'tornevall_wp_dnsbl_uninstall_db');
 
 tornevall_dnsbl_register_hooks();
+\Tornevall\Networks\DNSBL\Integration::registerHooks();


### PR DESCRIPTION
Closes #25

## Summary

- exposes a stable generic plugin-to-plugin DNSBL bridge for Tornevall WordPress addons
- keeps `tornevall_dnsbl_capabilities`, `tornevall_dnsbl_check_ip`, and `tornevall_dnsbl_report_ip` generic rather than guestbook-specific
- lets callers provide source type/name/note, site metadata and bitmask for future guestbook, Akismet, comments, registration and form consumers
- defaults generic web abuse to `IP_ABUSE_NO_SMTP` (64)
- reports are possible only when this DNSBL plugin is installed/active and its configured token is active with add permission
- exposes whether the delegated token also has `can_custom_txt`
- caller-defined `source_note` is forwarded only when token-info confirms custom-TXT permission; otherwise the DNSBL classification may still be published without caller-defined TXT text
- avoids duplicate add attempts when the IP already contains the requested classification
- never auto-reports merely because a consumer rejects content
- keeps the DNSBL token server-side
- bumps plugin metadata to 3.1.6 and updates documentation

## Initial consumer

Tornevall Tools for WordPress uses the bridge for guestbook IP checks and explicit administrator abuse reporting. The contract itself is not tied to guestbooks and is ready for later Akismet/comment/registration integrations.

## Security

Blacklist publication is always an explicit administrator action. A consumer that cannot see this plugin's capabilities gets no report path at all. Caller-defined TXT metadata is treated as a separate delegated privilege and is not sent unless the token is allowed to use it. Source TXT data is public DNS data, so names, e-mail addresses and message bodies must never be placed there.