### PR TITLE
Include phishing in installation filter defaults

### DIFF
--- a/includes/class-dnsbl-migrations.php
+++ b/includes/class-dnsbl-migrations.php
@@ -121,6 +121,12 @@ class Migrations
     {
         foreach (Plugin::defaultOptions() as $key => $value) {
             if (get_option($key) === false) {
+                if ($key === 'tornevall_dnsbl_filter_types'
+                    && is_array($value)
+                    && !in_array('IP_PHISHING', $value, true)) {
+                    $value[] = 'IP_PHISHING';
+                }
+
                 add_option($key, $value);
             }
         }

--- a/includes/class-dnsbl-migrations.php
+++ b/includes/class-dnsbl-migrations.php
@@ -8,6 +8,8 @@ if (!defined('ABSPATH')) {
 
 class Migrations
 {
+    private const PHISHING_DEFAULT_MIGRATION_OPTION = 'tornevall_dnsbl_phishing_default_migrated';
+
     public static function maybeUpgrade(): void
     {
         $dbVersion = get_option('tornevall_dnsbl_database_version');
@@ -147,7 +149,29 @@ class Migrations
         }
 
         Plugin::maybeUpgradeSelectedFlags();
+        self::maybeEnablePhishingDefault();
         self::maybeAddMissingResolverHosts();
+    }
+
+    /**
+     * Enable phishing filtering once for installs that predate it as a default.
+     *
+     * The migration marker prevents a later manual opt-out from being silently
+     * reverted by ensureDefaultOptions() on subsequent requests.
+     */
+    public static function maybeEnablePhishingDefault(): void
+    {
+        if (get_option(self::PHISHING_DEFAULT_MIGRATION_OPTION) === '1') {
+            return;
+        }
+
+        $selected = Plugin::normalizeSelectedFlags(get_option('tornevall_dnsbl_filter_types'));
+        if (!in_array('IP_PHISHING', $selected, true)) {
+            $selected[] = 'IP_PHISHING';
+            update_option('tornevall_dnsbl_filter_types', $selected);
+        }
+
+        update_option(self::PHISHING_DEFAULT_MIGRATION_OPTION, '1');
     }
 
     /**
@@ -236,6 +260,7 @@ class Migrations
             'tornevall_dnsbl_registration_dnsbl_enabled',
             'tornevall_dnsbl_registration_turnstile_enabled',
             'tornevall_dnsbl_rating_notice_dismissed',
+            self::PHISHING_DEFAULT_MIGRATION_OPTION,
             'tornevall_dnsbl_database_version',
         ];
 


### PR DESCRIPTION
Closes #5

## Summary

- Enables `IP_PHISHING` for new installations when the DNSBL filter option is created.
- Performs a one-time migration for existing installations that do not currently use `IP_PHISHING`, so they also receive the new default.
- Stores a migration marker after that one-time change. If an administrator later disables phishing filtering manually, normal plugin startup will not silently enable it again.
- Targets the `3.1` / `3.1.6` maintenance line. No release tag is created.

## Migration behavior

`IP_PHISHING` has not previously been an installation default, so existing installs cannot reliably distinguish "never enabled" from an old explicit selection. This migration therefore enables it once for every installation where it is currently absent. After that migration has run, the administrator remains in control of the setting.

## Validation

- The change remains isolated to `Migrations::ensureDefaultOptions()` plus the one-time migration helper and uninstall cleanup.
- No database schema version bump is required because this only updates WordPress options.
- Duplicate `IP_PHISHING` entries are prevented with an exact `in_array(..., true)` check.
- The migration marker prevents repeated re-enabling after a later manual opt-out.