### PR TITLE
Automate forward sync from 3.1 to master and 3.2

### DIFF
--- a/.github/workflows/forward-sync-3.1-to-3.2.yml
+++ b/.github/workflows/forward-sync-3.1-to-3.2.yml
@@ -1,4 +1,4 @@
-name: Forward sync 3.1 to 3.2
+name: Forward sync 3.1
 
 on:
   push:
@@ -11,9 +11,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  open-sync-pr:
-    name: Open 3.1 to 3.2 sync PR
+  open-sync-prs:
+    name: Open 3.1 forward-sync PRs
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        base:
+          - master
+          - '3.2'
 
     steps:
       - name: Check and open forward-sync pull request
@@ -23,7 +29,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const head = '3.1';
-            const base = '3.2';
+            const base = '${{ matrix.base }}';
 
             const comparison = await github.rest.repos.compareCommitsWithBasehead({
               owner,
@@ -46,7 +52,7 @@ jobs:
             });
 
             if (existing.data.length > 0) {
-              core.info(`Forward-sync PR already open: #${existing.data[0].number}`);
+              core.info(`Forward-sync PR already open for ${base}: #${existing.data[0].number}`);
               return;
             }
 
@@ -57,12 +63,12 @@ jobs:
               base,
               title: `Forward sync ${head} into ${base}`,
               body: [
-                'Automated forward-sync PR for the parallel 3.1/3.2 development period.',
+                'Automated forward-sync PR while 3.1 is the current stable line.',
                 '',
                 `This PR carries changes merged into \`${head}\` forward into \`${base}\`.`,
                 '',
-                'Conflicts must be resolved explicitly. This workflow never force-merges or silently resolves conflicts.',
+                'No release tag is created. Conflicts must be resolved explicitly; this workflow never force-merges or silently resolves conflicts.',
               ].join('\n'),
             });
 
-            core.info(`Created forward-sync PR #${created.data.number}.`);
+            core.info(`Created forward-sync PR #${created.data.number} for ${base}.`);

--- a/.github/workflows/forward-sync-3.1-to-3.2.yml
+++ b/.github/workflows/forward-sync-3.1-to-3.2.yml
@@ -1,0 +1,68 @@
+name: Forward sync 3.1 to 3.2
+
+on:
+  push:
+    branches:
+      - '3.1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-sync-pr:
+    name: Open 3.1 to 3.2 sync PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check and open forward-sync pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = '3.1';
+            const base = '3.2';
+
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${base}...${head}`,
+            });
+
+            if (comparison.data.ahead_by === 0) {
+              core.info(`${base} already contains all commits from ${head}.`);
+              return;
+            }
+
+            const existing = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${head}`,
+              base,
+              per_page: 100,
+            });
+
+            if (existing.data.length > 0) {
+              core.info(`Forward-sync PR already open: #${existing.data[0].number}`);
+              return;
+            }
+
+            const created = await github.rest.pulls.create({
+              owner,
+              repo,
+              head,
+              base,
+              title: `Forward sync ${head} into ${base}`,
+              body: [
+                'Automated forward-sync PR for the parallel 3.1/3.2 development period.',
+                '',
+                `This PR carries changes merged into \`${head}\` forward into \`${base}\`.`,
+                '',
+                'Conflicts must be resolved explicitly. This workflow never force-merges or silently resolves conflicts.',
+              ].join('\n'),
+            });
+
+            core.info(`Created forward-sync PR #${created.data.number}.`);


### PR DESCRIPTION
Closes #31.

## Summary

Adds a GitHub Actions workflow for the period where `3.1` is the current stable line and `3.2` is developed in parallel.

On every push to `3.1`, and on manual dispatch, the workflow checks both `master` and `3.2`.

For each target:

- If the target already contains all `3.1` commits, it does nothing.
- If an open `3.1` -> target PR already exists, it reuses that PR automatically because the head branch advances with `3.1`.
- Otherwise it opens a new forward-sync PR.
- It never creates release tags.
- It never force-merges and never resolves conflicts silently.

This keeps `master` aligned with the current stable 3.1 line while also keeping 3.2 downstream from 3.1 until the parallel-development period ends.