### PR TITLE
CI: run WordPress Plugin Check in GitHub Actions

### DIFF
--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,34 @@
+name: WordPress Plugin Check
+
+on:
+  pull_request:
+    branches:
+      - '3.1'
+      - '3.2'
+  push:
+    branches:
+      - '3.1'
+      - '3.2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wordpress-plugin-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-check:
+    name: WordPress Plugin Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out plugin
+        uses: actions/checkout@v4
+
+      - name: Run WordPress Plugin Check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: './'
+          strict: false


### PR DESCRIPTION
Adds the official WordPress Plugin Check action as a dedicated CI workflow.

- Runs on pull requests targeting `3.1` and `3.2` once present on those branches.
- Runs on pushes to the active development lines.
- Uses the plugin repository root as the Plugin Check build directory.
- Real Plugin Check errors fail the job; warnings remain visible without making the first baseline unusably strict.
- Keeps Plugin Check separate from existing/unit test coverage.

Closes #33