### PR TITLE
Sync 3.1 stable line into master

### DIFF
--- a/includes/class-dnsbl-migrations.php
+++ b/includes/class-dnsbl-migrations.php
@@ -121,6 +121,12 @@ class Migrations
     {
         foreach (Plugin::defaultOptions() as $key => $value) {
             if (get_option($key) === false) {
+                if ($key === 'tornevall_dnsbl_filter_types'
+                    && is_array($value)
+                    && !in_array('IP_PHISHING', $value, true)) {
+                    $value[] = 'IP_PHISHING';
+                }
+
                 add_option($key, $value);
             }
         }

--- a/includes/class-dnsbl-migrations.php
+++ b/includes/class-dnsbl-migrations.php
@@ -8,6 +8,8 @@ if (!defined('ABSPATH')) {
 
 class Migrations
 {
+    private const PHISHING_DEFAULT_MIGRATION_OPTION = 'tornevall_dnsbl_phishing_default_migrated';
+
     public static function maybeUpgrade(): void
     {
         $dbVersion = get_option('tornevall_dnsbl_database_version');
@@ -147,7 +149,29 @@ class Migrations
         }
 
         Plugin::maybeUpgradeSelectedFlags();
+        self::maybeEnablePhishingDefault();
         self::maybeAddMissingResolverHosts();
+    }
+
+    /**
+     * Enable phishing filtering once for installs that predate it as a default.
+     *
+     * The migration marker prevents a later manual opt-out from being silently
+     * reverted by ensureDefaultOptions() on subsequent requests.
+     */
+    public static function maybeEnablePhishingDefault(): void
+    {
+        if (get_option(self::PHISHING_DEFAULT_MIGRATION_OPTION) === '1') {
+            return;
+        }
+
+        $selected = Plugin::normalizeSelectedFlags(get_option('tornevall_dnsbl_filter_types'));
+        if (!in_array('IP_PHISHING', $selected, true)) {
+            $selected[] = 'IP_PHISHING';
+            update_option('tornevall_dnsbl_filter_types', $selected);
+        }
+
+        update_option(self::PHISHING_DEFAULT_MIGRATION_OPTION, '1');
     }
 
     /**
@@ -236,6 +260,7 @@ class Migrations
             'tornevall_dnsbl_registration_dnsbl_enabled',
             'tornevall_dnsbl_registration_turnstile_enabled',
             'tornevall_dnsbl_rating_notice_dismissed',
+            self::PHISHING_DEFAULT_MIGRATION_OPTION,
             'tornevall_dnsbl_database_version',
         ];
 


### PR DESCRIPTION
Synchronizes the current 3.1 stable/development line into master.

- 3.1 is the current stable line.
- Everything currently in 3.1 is approved to flow to master.
- This does not create or publish a 3.1.6 tag/release.
- 3.2 remains downstream and is synchronized separately.