### PR TITLE
Promote stable 3.1 line to master

### DIFF
--- a/.github/workflows/forward-sync-3.1-to-3.2.yml
+++ b/.github/workflows/forward-sync-3.1-to-3.2.yml
@@ -1,4 +1,4 @@
-name: Forward sync 3.1 to 3.2
+name: Forward sync 3.1
 
 on:
   push:
@@ -11,9 +11,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  open-sync-pr:
-    name: Open 3.1 to 3.2 sync PR
+  open-sync-prs:
+    name: Open 3.1 forward-sync PRs
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        base:
+          - master
+          - '3.2'
 
     steps:
       - name: Check and open forward-sync pull request
@@ -23,7 +29,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const head = '3.1';
-            const base = '3.2';
+            const base = '${{ matrix.base }}';
 
             const comparison = await github.rest.repos.compareCommitsWithBasehead({
               owner,
@@ -46,7 +52,7 @@ jobs:
             });
 
             if (existing.data.length > 0) {
-              core.info(`Forward-sync PR already open: #${existing.data[0].number}`);
+              core.info(`Forward-sync PR already open for ${base}: #${existing.data[0].number}`);
               return;
             }
 
@@ -57,12 +63,12 @@ jobs:
               base,
               title: `Forward sync ${head} into ${base}`,
               body: [
-                'Automated forward-sync PR for the parallel 3.1/3.2 development period.',
+                'Automated forward-sync PR while 3.1 is the current stable line.',
                 '',
                 `This PR carries changes merged into \`${head}\` forward into \`${base}\`.`,
                 '',
-                'Conflicts must be resolved explicitly. This workflow never force-merges or silently resolves conflicts.',
+                'No release tag is created. Conflicts must be resolved explicitly; this workflow never force-merges or silently resolves conflicts.',
               ].join('\n'),
             });
 
-            core.info(`Created forward-sync PR #${created.data.number}.`);
+            core.info(`Created forward-sync PR #${created.data.number} for ${base}.`);

--- a/.github/workflows/forward-sync-3.1-to-3.2.yml
+++ b/.github/workflows/forward-sync-3.1-to-3.2.yml
@@ -1,0 +1,68 @@
+name: Forward sync 3.1 to 3.2
+
+on:
+  push:
+    branches:
+      - '3.1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-sync-pr:
+    name: Open 3.1 to 3.2 sync PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check and open forward-sync pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = '3.1';
+            const base = '3.2';
+
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${base}...${head}`,
+            });
+
+            if (comparison.data.ahead_by === 0) {
+              core.info(`${base} already contains all commits from ${head}.`);
+              return;
+            }
+
+            const existing = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${head}`,
+              base,
+              per_page: 100,
+            });
+
+            if (existing.data.length > 0) {
+              core.info(`Forward-sync PR already open: #${existing.data[0].number}`);
+              return;
+            }
+
+            const created = await github.rest.pulls.create({
+              owner,
+              repo,
+              head,
+              base,
+              title: `Forward sync ${head} into ${base}`,
+              body: [
+                'Automated forward-sync PR for the parallel 3.1/3.2 development period.',
+                '',
+                `This PR carries changes merged into \`${head}\` forward into \`${base}\`.`,
+                '',
+                'Conflicts must be resolved explicitly. This workflow never force-merges or silently resolves conflicts.',
+              ].join('\n'),
+            });
+
+            core.info(`Created forward-sync PR #${created.data.number}.`);

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,34 @@
+name: WordPress Plugin Check
+
+on:
+  pull_request:
+    branches:
+      - '3.1'
+      - '3.2'
+  push:
+    branches:
+      - '3.1'
+      - '3.2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wordpress-plugin-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-check:
+    name: WordPress Plugin Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out plugin
+        uses: actions/checkout@v4
+
+      - name: Run WordPress Plugin Check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: './'
+          strict: false


### PR DESCRIPTION
Promotes the current stable `3.1` line into `master`.

- Both branches already identify the plugin as version `3.1.6`.
- This syncs the current stable branch history and CI workflow state into `master`.
- No `3.1.6` release tag is created or published.
- `3.2` remains a separate development line and should continue receiving forward-syncs from `3.1` while both lines are active.

Closes #36