### PR TITLE
Add explicit opt-in batched usage telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,56 @@
+# Opt-in usage statistics
+
+Tornevall Networks DNSBL can send aggregate usage statistics to Tornevall Tools only after a WordPress administrator explicitly enables the telemetry checkbox.
+
+## Default state
+
+Telemetry is disabled by default. Configuring a DNSBL / Tools API token does not enable telemetry and is not treated as consent.
+
+When telemetry is enabled for the first time, the cursor is moved to the current end of the local DNSBL statistics table. Existing statistics collected before consent are therefore not sent retroactively.
+
+Disabling telemetry stops the telemetry WP-Cron schedule and discards any unsent pending telemetry batch.
+
+## What is sent
+
+The plugin reads its existing local `dnsblstats` rows and aggregates them before transmission. A batch can contain:
+
+- schema version
+- random batch ID used for idempotent retries
+- plugin version
+- reporting period start and end
+- aggregate DNSBL evaluation rows containing:
+  - returned bitmask
+  - listed / not listed result
+  - blocked / not blocked decision
+  - internal source category such as `request`, `admin-request`, or `dry-run-request`
+  - count for that combination
+
+The plugin does not include queried or visitor IP addresses, comments, usernames, email addresses, site URLs, hostnames, or raw DNS responses in telemetry batches.
+
+## Transport and authentication
+
+Batches are sent over HTTPS to the configured Tornevall Tools environment at:
+
+`POST /api/dnsbl/telemetry/batch`
+
+The existing DNSBL / Tools API token is supplied in the `X-Dnsbl-Token` request header for authentication. The token is not duplicated inside the telemetry JSON body.
+
+Tornevall Tools attributes accepted statistics internally to the authenticated token and token owner. The telemetry endpoint is write-only for the WordPress plugin and does not provide the sending site with a telemetry readback API.
+
+## Frequency and retry behavior
+
+Telemetry is scheduled with WordPress WP-Cron and normally sends at most one batch per hour. WP-Cron runs when WordPress receives traffic, so actual delivery can be later on low-traffic sites.
+
+A pending batch keeps the same batch ID until Tools acknowledges it. If a request fails or times out, the local cursor is not advanced and the same batch is retried on a later run. Tools treats the token + batch ID combination as idempotent so a retry cannot intentionally count the same accepted batch twice.
+
+## WordPress privacy integration
+
+The plugin registers suggested privacy-policy text with `wp_add_privacy_policy_content()` so site administrators can disclose the optional telemetry through WordPress' built-in Privacy Policy Guide.
+
+The WordPress.org plugin readme also documents the external service, data categories, opt-in behavior, and transmission frequency.
+
+Tornevall Tools documentation: https://tools.tornevall.net/docs
+
+Privacy policy: https://tools.tornevall.net/docs/en/privacy-policy
+
+Terms of service: https://tools.tornevall.net/docs/en/terms-of-service

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -37,6 +37,8 @@ The existing DNSBL / Tools API token is supplied in the `X-Dnsbl-Token` request 
 
 Tornevall Tools attributes accepted statistics internally to the authenticated token and token owner. The telemetry endpoint is write-only for the WordPress plugin and does not provide the sending site with a telemetry readback API.
 
+As with any HTTPS request, the sending WordPress server's network IP address is necessarily visible to Tornevall Tools and can be present in normal server/API request logs. This transport metadata is separate from the aggregate telemetry payload and is not the visitor/query IP address being evaluated by DNSBL.
+
 ## Frequency and retry behavior
 
 Telemetry is scheduled with WordPress WP-Cron and normally sends at most one batch per hour. WP-Cron runs when WordPress receives traffic, so actual delivery can be later on low-traffic sites.

--- a/includes/class-dnsbl-telemetry.php
+++ b/includes/class-dnsbl-telemetry.php
@@ -1,0 +1,380 @@
+<?php
+
+namespace Tornevall\Networks\DNSBL;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Explicit opt-in telemetry for aggregate DNSBL usage statistics.
+ *
+ * The telemetry path never sends queried IP addresses, comments, usernames,
+ * site URLs, or raw DNS responses. It aggregates the plugin's existing local
+ * dnsblstats rows and submits one periodic batch through the configured Tools
+ * DNSBL token.
+ */
+class Telemetry
+{
+    private const CONSENT_OPTION = 'tornevall_dnsbl_telemetry_consent';
+    private const DECIDED_OPTION = 'tornevall_dnsbl_telemetry_consent_decided';
+    private const CURSOR_OPTION = 'tornevall_dnsbl_telemetry_cursor';
+    private const PENDING_OPTION = 'tornevall_dnsbl_telemetry_pending_batch';
+    private const LAST_SENT_OPTION = 'tornevall_dnsbl_telemetry_last_sent';
+    private const CRON_HOOK = 'tornevall_dnsbl_telemetry_flush';
+    private const ADMIN_ACTION = 'tornevall_dnsbl_save_telemetry_consent';
+    private const ENDPOINT = '/api/dnsbl/telemetry/batch';
+    private const SCHEMA_VERSION = 1;
+
+    public static function registerHooks(): void
+    {
+        add_action('init', [self::class, 'syncSchedule']);
+        add_action(self::CRON_HOOK, [self::class, 'flush']);
+        add_action('admin_post_' . self::ADMIN_ACTION, [self::class, 'handleConsentSave']);
+        add_action('admin_notices', [self::class, 'renderConsentControl']);
+        add_action('admin_init', [self::class, 'addPrivacyPolicyContent']);
+    }
+
+    public static function consentEnabled(): bool
+    {
+        return get_option(self::CONSENT_OPTION) === '1';
+    }
+
+    public static function consentDecided(): bool
+    {
+        return get_option(self::DECIDED_OPTION) === '1';
+    }
+
+    public static function syncSchedule(): void
+    {
+        if (!function_exists('wp_next_scheduled')) {
+            return;
+        }
+
+        $shouldSchedule = self::consentEnabled() && Plugin::apiToken() !== '';
+        $scheduled = wp_next_scheduled(self::CRON_HOOK);
+
+        if (!$shouldSchedule) {
+            if ($scheduled && function_exists('wp_clear_scheduled_hook')) {
+                wp_clear_scheduled_hook(self::CRON_HOOK);
+            }
+            return;
+        }
+
+        if (!$scheduled) {
+            wp_schedule_event(time() + HOUR_IN_SECONDS, 'hourly', self::CRON_HOOK);
+        }
+    }
+
+    public static function clearSchedule(): void
+    {
+        if (function_exists('wp_clear_scheduled_hook')) {
+            wp_clear_scheduled_hook(self::CRON_HOOK);
+        }
+    }
+
+    public static function handleConsentSave(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('You do not have permission to change DNSBL telemetry settings.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        check_admin_referer(self::ADMIN_ACTION);
+
+        $enabled = isset($_POST['tornevall_dnsbl_telemetry_consent'])
+            && sanitize_key(wp_unslash($_POST['tornevall_dnsbl_telemetry_consent'])) === '1';
+        $wasEnabled = self::consentEnabled();
+
+        update_option(self::CONSENT_OPTION, $enabled ? '1' : '0', false);
+        update_option(self::DECIDED_OPTION, '1', false);
+
+        if ($enabled && !$wasEnabled) {
+            self::moveCursorToCurrentEnd();
+            delete_option(self::PENDING_OPTION);
+        }
+
+        if (!$enabled) {
+            self::moveCursorToCurrentEnd();
+            delete_option(self::PENDING_OPTION);
+            self::clearSchedule();
+        } else {
+            self::syncSchedule();
+        }
+
+        $redirect = wp_get_referer();
+        if (!$redirect) {
+            $redirect = admin_url('admin.php?page=tornevallDnsblMenu');
+        }
+
+        $redirect = add_query_arg('tornevall_dnsbl_telemetry_saved', '1', $redirect);
+        wp_safe_redirect($redirect);
+        exit;
+    }
+
+    public static function renderConsentControl(): void
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $onPluginPage = isset($_GET['page'])
+            && sanitize_key(wp_unslash($_GET['page'])) === sanitize_key('tornevallDnsblMenu');
+
+        if (self::consentDecided() && !$onPluginPage) {
+            return;
+        }
+
+        $enabled = self::consentEnabled();
+        $tokenConfigured = Plugin::apiToken() !== '';
+        $saved = isset($_GET['tornevall_dnsbl_telemetry_saved'])
+            && sanitize_key(wp_unslash($_GET['tornevall_dnsbl_telemetry_saved'])) === '1';
+
+        $classes = $saved ? 'notice notice-success' : 'notice notice-info';
+        ?>
+        <div class="<?php echo esc_attr($classes); ?>">
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="padding:10px 0;">
+                <input type="hidden" name="action" value="<?php echo esc_attr(self::ADMIN_ACTION); ?>">
+                <?php wp_nonce_field(self::ADMIN_ACTION); ?>
+                <p style="margin-top:0;"><strong><?php echo esc_html__('Tornevall DNSBL usage statistics', 'tornevall-networks-dnsbl-implementation'); ?></strong></p>
+                <label for="tornevall_dnsbl_telemetry_consent" style="display:block; margin:8px 0;">
+                    <input type="checkbox"
+                           id="tornevall_dnsbl_telemetry_consent"
+                           name="tornevall_dnsbl_telemetry_consent"
+                           value="1"
+                           <?php checked($enabled); ?>>
+                    <?php echo esc_html__('Allow this plugin to send anonymous aggregate usage statistics to Tornevall Tools.', 'tornevall-networks-dnsbl-implementation'); ?>
+                </label>
+                <p class="description" style="max-width:900px;">
+                    <?php echo esc_html__('When enabled, the plugin batches aggregate DNSBL evaluation counts such as listed/not-listed outcomes, returned bitmasks, blocked/not-blocked decisions, source category, plugin version, and reporting window. Queried visitor IP addresses, comments, usernames, site URLs, and raw DNS responses are not included. Batches are normally sent about once per hour through WP-Cron and authenticated with the configured DNSBL / Tools API token. The token itself is not included in the telemetry payload.', 'tornevall-networks-dnsbl-implementation'); ?>
+                </p>
+                <?php if (!$tokenConfigured) { ?>
+                    <p class="description">
+                        <?php echo esc_html__('Telemetry cannot be sent until a DNSBL / Tools API token is configured. Consent may still be saved in advance.', 'tornevall-networks-dnsbl-implementation'); ?>
+                    </p>
+                <?php } ?>
+                <p>
+                    <button type="submit" class="button button-secondary">
+                        <?php echo esc_html__('Save usage statistics preference', 'tornevall-networks-dnsbl-implementation'); ?>
+                    </button>
+                    <?php if ($saved) { ?>
+                        <span style="margin-left:8px;"><?php echo esc_html__('Preference saved.', 'tornevall-networks-dnsbl-implementation'); ?></span>
+                    <?php } ?>
+                </p>
+            </form>
+        </div>
+        <?php
+    }
+
+    public static function addPrivacyPolicyContent(): void
+    {
+        if (!function_exists('wp_add_privacy_policy_content')) {
+            return;
+        }
+
+        $content = '<p class="privacy-policy-tutorial">'
+            . esc_html__('Tornevall DNSBL includes optional aggregate usage statistics. The feature is disabled by default and requires an administrator opt-in.', 'tornevall-networks-dnsbl-implementation')
+            . '</p>'
+            . '<strong class="privacy-policy-tutorial">'
+            . esc_html__('Suggested text:', 'tornevall-networks-dnsbl-implementation')
+            . '</strong> '
+            . '<p>'
+            . esc_html__('If the site administrator enables Tornevall DNSBL usage statistics, this site periodically sends aggregate DNSBL evaluation counts to Tornevall Tools. The statistics can include listed/not-listed outcomes, DNSBL bitmasks, blocked/not-blocked decisions, source categories, plugin version, and reporting time windows. Queried visitor IP addresses, comments, usernames, site URLs, and raw DNS responses are not included in these telemetry batches. The batches are authenticated using the site administrator\'s configured DNSBL / Tools API token and are normally sent about once per hour through WordPress cron.', 'tornevall-networks-dnsbl-implementation')
+            . '</p>';
+
+        wp_add_privacy_policy_content(
+            __('Tornevall Networks DNSBL Implementation', 'tornevall-networks-dnsbl-implementation'),
+            wp_kses_post(wpautop($content, false))
+        );
+    }
+
+    public static function flush(): void
+    {
+        if (!self::consentEnabled() || Plugin::apiToken() === '') {
+            self::clearSchedule();
+            return;
+        }
+
+        $pending = get_option(self::PENDING_OPTION);
+        if (!is_array($pending) || empty($pending['payload']) || empty($pending['cursor_to'])) {
+            $pending = self::buildPendingBatch();
+            if (!$pending) {
+                return;
+            }
+            update_option(self::PENDING_OPTION, $pending, false);
+        }
+
+        $response = self::sendPayload((array)$pending['payload']);
+        if (!$response['ok']) {
+            return;
+        }
+
+        update_option(self::CURSOR_OPTION, (int)$pending['cursor_to'], false);
+        update_option(self::LAST_SENT_OPTION, time(), false);
+        delete_option(self::PENDING_OPTION);
+    }
+
+    /**
+     * @return array{payload:array<string,mixed>,cursor_to:int}|null
+     */
+    private static function buildPendingBatch(): ?array
+    {
+        global $wpdb;
+
+        $table = Plugin::getStatsTableName($wpdb);
+        if (!Plugin::tableExists($wpdb, $table)) {
+            return null;
+        }
+
+        $cursor = max(0, (int)get_option(self::CURSOR_OPTION, 0));
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived internally from the trusted WordPress table prefix.
+        $cursorTo = (int)$wpdb->get_var("SELECT MAX(id) FROM {$table}");
+        if ($cursorTo <= $cursor) {
+            return null;
+        }
+
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived internally from the trusted WordPress table prefix.
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT resolveTime AS bitmask, wasBlocked, COALESCE(NULLIF(source, ''), 'request') AS source, COUNT(*) AS event_count, MIN(createdAt) AS first_seen, MAX(createdAt) AS last_seen FROM {$table} WHERE id > %d AND id <= %d GROUP BY resolveTime, wasBlocked, source ORDER BY resolveTime ASC, wasBlocked ASC, source ASC",
+                $cursor,
+                $cursorTo
+            ),
+            ARRAY_A
+        );
+        // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+        if (!is_array($rows) || !$rows) {
+            update_option(self::CURSOR_OPTION, $cursorTo, false);
+            return null;
+        }
+
+        $events = [];
+        $periodStart = null;
+        $periodEnd = null;
+
+        foreach ($rows as $row) {
+            $count = max(0, (int)($row['event_count'] ?? 0));
+            if ($count < 1) {
+                continue;
+            }
+
+            $bitmask = max(0, min(65535, (int)($row['bitmask'] ?? 0)));
+            $blocked = !empty($row['wasBlocked']);
+            $source = sanitize_key((string)($row['source'] ?? 'request'));
+            if ($source === '') {
+                $source = 'request';
+            }
+
+            $firstSeen = self::normalizeMysqlUtc((string)($row['first_seen'] ?? ''));
+            $lastSeen = self::normalizeMysqlUtc((string)($row['last_seen'] ?? ''));
+            if ($firstSeen !== null && ($periodStart === null || $firstSeen < $periodStart)) {
+                $periodStart = $firstSeen;
+            }
+            if ($lastSeen !== null && ($periodEnd === null || $lastSeen > $periodEnd)) {
+                $periodEnd = $lastSeen;
+            }
+
+            $events[] = [
+                'type' => 'dnsbl_evaluation',
+                'bitmask' => $bitmask,
+                'listed' => $bitmask > 0,
+                'blocked' => $blocked,
+                'source' => substr($source, 0, 32),
+                'count' => $count,
+            ];
+        }
+
+        if (!$events) {
+            update_option(self::CURSOR_OPTION, $cursorTo, false);
+            return null;
+        }
+
+        return [
+            'cursor_to' => $cursorTo,
+            'payload' => [
+                'schema_version' => self::SCHEMA_VERSION,
+                'batch_id' => wp_generate_uuid4(),
+                'plugin_version' => defined('TORNEVALL_DNSBL_PLUGIN_VERSION') ? (string)TORNEVALL_DNSBL_PLUGIN_VERSION : '',
+                'period_start' => $periodStart,
+                'period_end' => $periodEnd,
+                'events' => $events,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{ok:bool,status:int}
+     */
+    private static function sendPayload(array $payload): array
+    {
+        $token = Plugin::apiToken();
+        $baseUrl = untrailingslashit(rtrim((string)Plugin::toolsBaseUrl(), '/'));
+        if ($token === '' || $baseUrl === '') {
+            return ['ok' => false, 'status' => 0];
+        }
+
+        $response = wp_remote_post($baseUrl . self::ENDPOINT, [
+            'timeout' => 15,
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'X-Dnsbl-Token' => $token,
+            ],
+            'body' => wp_json_encode($payload),
+        ]);
+
+        if (is_wp_error($response)) {
+            return ['ok' => false, 'status' => 0];
+        }
+
+        $status = (int)wp_remote_retrieve_response_code($response);
+        return [
+            'ok' => $status >= 200 && $status < 300,
+            'status' => $status,
+        ];
+    }
+
+    private static function moveCursorToCurrentEnd(): void
+    {
+        global $wpdb;
+
+        $table = Plugin::getStatsTableName($wpdb);
+        if (!Plugin::tableExists($wpdb, $table)) {
+            update_option(self::CURSOR_OPTION, 0, false);
+            return;
+        }
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived internally from the trusted WordPress table prefix.
+        $lastId = (int)$wpdb->get_var("SELECT MAX(id) FROM {$table}");
+        update_option(self::CURSOR_OPTION, max(0, $lastId), false);
+    }
+
+    private static function normalizeMysqlUtc(string $value): ?string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        $timestamp = strtotime($value . ' UTC');
+        if ($timestamp === false) {
+            return null;
+        }
+
+        return gmdate('c', $timestamp);
+    }
+
+    public static function uninstall(): void
+    {
+        self::clearSchedule();
+        foreach ([
+            self::CONSENT_OPTION,
+            self::DECIDED_OPTION,
+            self::CURSOR_OPTION,
+            self::PENDING_OPTION,
+            self::LAST_SENT_OPTION,
+        ] as $option) {
+            delete_option($option);
+        }
+    }
+}

--- a/includes/dnsbl-utils.php
+++ b/includes/dnsbl-utils.php
@@ -2,6 +2,7 @@
 
 use Tornevall\Networks\DNSBL\Migrations;
 use Tornevall\Networks\DNSBL\Plugin;
+use Tornevall\Networks\DNSBL\Telemetry;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -24,11 +25,13 @@ function tornevall_wp_dnsbl_activate_db()
 
 function tornevall_wp_dnsbl_deactivate_db()
 {
+    Telemetry::clearSchedule();
     Migrations::deactivate();
 }
 
 function tornevall_wp_dnsbl_uninstall_db()
 {
+    Telemetry::uninstall();
     Migrations::uninstall();
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,30 @@ Full Documentation: [DNSBL API documentation](https://tools.tornevall.net/docs/d
 
 Translations can be contributed via [translate.wordpress.org](https://translate.wordpress.org/projects/wp-plugins/tornevall-networks-dnsbl-implementation).
 
+= Privacy and optional usage statistics =
+
+The plugin includes optional aggregate usage statistics. This telemetry is disabled by default and is only enabled after a WordPress administrator explicitly checks the usage-statistics consent checkbox and saves the preference. Configuring a DNSBL / Tools API token does not enable telemetry and is not treated as consent.
+
+When enabled, the plugin periodically sends aggregated DNSBL evaluation counters to Tornevall Tools. A batch can contain the plugin version, reporting time window, DNSBL listed/not-listed outcomes, returned bitmasks, blocked/not-blocked decisions, internal source categories such as request/admin-request/dry-run-request, and a count for each aggregate combination.
+
+Telemetry batches do not include queried or visitor IP addresses, comments, usernames, email addresses, site URLs, hostnames, or raw DNS responses. Statistics collected locally before the administrator opts in are not sent retroactively.
+
+Telemetry is normally sent at most once per hour through WordPress WP-Cron. Low-traffic sites may send later because WP-Cron is traffic-driven. Failed or timed-out submissions keep the same batch ID for a later retry so the Tools receiver can treat the batch idempotently instead of counting it twice.
+
+The telemetry request is sent over HTTPS to the selected Tornevall Tools environment and authenticated with the configured DNSBL / Tools API token in the `X-Dnsbl-Token` header. The token is not included inside the telemetry JSON body. Tornevall Tools attributes accepted statistics internally to the authenticated token and token owner. The plugin does not expose a telemetry readback function to the sending site.
+
+Turning telemetry off stops the telemetry schedule and discards any unsent telemetry batch. The plugin also adds suggested disclosure text to WordPress' built-in Privacy Policy Guide.
+
+External service: [Tornevall Tools](https://tools.tornevall.net/)
+
+Service documentation: [Tornevall Tools documentation](https://tools.tornevall.net/docs)
+
+Privacy Policy: [Tornevall Tools Privacy Policy](https://tools.tornevall.net/docs/en/privacy-policy)
+
+Terms of Service: [Tornevall Tools Terms of Service](https://tools.tornevall.net/docs/en/terms-of-service)
+
+Technical telemetry details are also documented in `TELEMETRY.md` in the plugin source repository.
+
 
 == Installation ==
 
@@ -60,6 +84,10 @@ But you need permissions for this, which can be gained by request via [https://t
 
 No. DNSBL is an optional protection add-on. A consumer such as Tornevall Tools for WordPress can continue without it. When DNSBL is active, the consumer can discover whether IP checking and explicit abuse reporting are available through the plugin integration filters.
 
+* Does the plugin send usage statistics?
+
+Only if a WordPress administrator explicitly opts in. Usage statistics are disabled by default. When enabled, aggregate DNSBL evaluation counters are batched and normally sent to Tornevall Tools at most once per hour through WP-Cron. Queried IP addresses, comments, usernames, email addresses, site URLs, hostnames, and raw DNS responses are not included in telemetry batches.
+
 
 == Screenshots ==
 
@@ -82,6 +110,10 @@ No. DNSBL is an optional protection add-on. A consumer such as Tornevall Tools f
 
 = 3.1.6 =
 
+* Added explicit opt-in aggregate DNSBL usage statistics with a separate administrator consent checkbox; configuring a token alone does not enable telemetry.
+* Usage statistics are aggregated locally and normally sent at most once per hour through WP-Cron instead of sending one report per lookup/evaluation.
+* Telemetry batches omit queried IP addresses, comments, usernames, email addresses, site URLs, hostnames, and raw DNS responses, and pre-consent history is not sent retroactively.
+* Added WordPress Privacy Policy Guide disclosure text and public telemetry/service documentation.
 * Added a stable plugin-to-plugin DNSBL integration bridge for optional Tornevall WordPress add-ons.
 * Consumers can discover check/report capability, check a visitor IP and explicitly report web/guestbook abuse without reading DNSBL plugin internals.
 * Guestbook/web abuse reports default to `IP_ABUSE_NO_SMTP` (64).
@@ -132,7 +164,7 @@ No. DNSBL is an optional protection add-on. A consumer such as Tornevall Tools f
 
 = 3.1.6 =
 
-Adds the optional DNSBL integration bridge used by Tornevall Tools for WordPress and future add-ons. Existing comment, registration and delisting behavior remains unchanged.
+Adds explicit optional usage-statistics consent and hourly aggregate telemetry batching. Telemetry is disabled by default and is never enabled merely by configuring a DNSBL / Tools API token. Also includes the optional DNSBL integration bridge used by Tornevall Tools for WordPress and future add-ons.
 
 = 3.1.5 =
 
@@ -148,7 +180,7 @@ Fixes the public removal-form Cloudflare Turnstile lifecycle for live delist sub
 
 = 3.1.1 =
 
-Urgent hotfix release. Adds a dedicated Turnstile toggle for the public delisting/removal page so Cloudflare issues there can be mitigated without turning off comment or registration protection.
+Urgent hotfix release. Adds a dedicated Turnstile toggle for the public delisting/removal page so Cloudflare issues there can be mitigated without turning off comment and registration protection.
 
 = 3.1.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Tornevall
 Tags: antispam, blacklist, fraud, comment spam, user registration
 Requires at least: 5.8
 Requires PHP: 8.1
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 3.1.6
 License: GPLv2 or later
 
@@ -180,7 +180,7 @@ Fixes the public removal-form Cloudflare Turnstile lifecycle for live delist sub
 
 = 3.1.1 =
 
-Urgent hotfix release. Adds a dedicated Turnstile toggle for the public delisting/removal page so Cloudflare issues there can be mitigated without turning off comment and registration protection.
+Urgent hotfix release. Adds a dedicated Turnstile toggle for the public delisting/removal page so Cloudflare issues there can be mitigated without turning off comment or registration protection.
 
 = 3.1.0 =
 

--- a/tornevall-wp-dnsbl.php
+++ b/tornevall-wp-dnsbl.php
@@ -7,6 +7,8 @@
  * Version: 3.1.6
  * Author: Thomas Tornevall
  * Author URI: https://www.tornevalls.se/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: tornevall-networks-dnsbl-implementation
  */
 

--- a/tornevall-wp-dnsbl.php
+++ b/tornevall-wp-dnsbl.php
@@ -30,6 +30,7 @@ foreach ([
     'includes/class-dnsbl-api-client.php',
     'includes/class-dnsbl-write-queue.php',
     'includes/class-dnsbl-integration.php',
+    'includes/class-dnsbl-telemetry.php',
     'includes/dnsbl-utils.php',
     'includes/dnsbl-migrations.php',
     'includes/dnsbl-bootstrap.php',
@@ -49,3 +50,4 @@ register_uninstall_hook(TORNEVALL_DNSBL_PLUGIN_FILE, 'tornevall_wp_dnsbl_uninsta
 
 tornevall_dnsbl_register_hooks();
 \Tornevall\Networks\DNSBL\Integration::registerHooks();
+\Tornevall\Networks\DNSBL\Telemetry::registerHooks();


### PR DESCRIPTION
Closes #6.

## Summary

Adds an explicit WordPress administrator consent flow for aggregate DNSBL usage statistics on the maintained `3.1` line. After merge, the existing forward-sync workflow carries the change to `master` and `3.2`.

- telemetry is disabled by default
- configuring a DNSBL / Tools API token does not count as telemetry consent
- first-time opt-in starts from the current local statistics cursor, so pre-consent history is not sent retroactively
- opting out stops the WP-Cron telemetry schedule and discards any unsent pending batch
- telemetry is aggregated from local DNSBL evaluation statistics before transmission
- normal delivery is at most one batch per hour through WP-Cron, rather than one request per DNSBL evaluation
- failed/time-out deliveries retain the same pending batch ID for idempotent retry
- payloads contain aggregate bitmask/listed/blocked/source counts, plugin version, and reporting window
- queried/visitor IP addresses, comments, usernames, email addresses, site URLs, hostnames, and raw DNS responses are not included in telemetry batches
- the existing DNSBL / Tools token is used only as the HTTPS authentication header; it is not embedded in the telemetry JSON body
- adds an administrator consent notice/checkbox and keeps the control visible on the DNSBL settings page after a decision
- registers suggested disclosure text with `wp_add_privacy_policy_content()`
- documents the external service, data categories, frequency, retry behaviour, Privacy Policy and Terms in `readme.txt` and `TELEMETRY.md`
- `TELEMETRY.md` also documents that the sending WordPress server's connection IP is inherently visible in the HTTPS connection and may appear in ordinary Tools request logs, separately from the telemetry payload
- synchronized with current `3.1`/`master` CI and metadata before merge

Tools receiver: Tornevall/toolsApi#428 (merged)

Validation: WordPress Plugin Check run #30 passed on the synchronized tree.

No version tag is created by this PR.