### PR TITLE
Run Plugin Check on master stable branch

### DIFF
--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -3,10 +3,12 @@ name: WordPress Plugin Check
 on:
   pull_request:
     branches:
+      - 'master'
       - '3.1'
       - '3.2'
   push:
     branches:
+      - 'master'
       - '3.1'
       - '3.2'
   workflow_dispatch:


### PR DESCRIPTION
Adds `master` to the existing WordPress Plugin Check pull-request and push triggers.

The existing `3.1`, `3.2`, and manual triggers remain unchanged.

This closes the stable-branch coverage gap while preserving the repository's 3.1 -> master and 3.1 -> 3.2 branch model.

Closes #44