### PR TITLE
Fix rewrite migration lifecycle for Plugin Check

### DIFF
--- a/includes/class-dnsbl-migrations.php
+++ b/includes/class-dnsbl-migrations.php
@@ -51,12 +51,19 @@ class Migrations
         self::ensureDefaultOptions();
 
         update_option('tornevall_dnsbl_database_version', self::schemaVersion());
-        Plugin::registerInternalDelistRewrite();
-        if (function_exists('flush_rewrite_rules')) {
-            flush_rewrite_rules(false);
-        }
+        self::refreshRewriteRulesAfterMigration();
         Plugin::syncCacheCleanupSchedule();
         Plugin::purgeExpiredCache();
+    }
+
+    private static function refreshRewriteRulesAfterMigration(): void
+    {
+        if (did_action('init')) {
+            Plugin::refreshInternalDelistRewriteRules(false);
+            return;
+        }
+
+        add_action('init', [Plugin::class, 'refreshInternalDelistRewriteRules'], 20);
     }
 
     /**
@@ -271,4 +278,3 @@ class Migrations
         }
     }
 }
-


### PR DESCRIPTION
Fixes the WP-CLI bootstrap fatal exposed by WordPress Plugin Check.

`Migrations::run()` no longer calls `add_rewrite_rule()` indirectly during `plugins_loaded`. Instead it refreshes rewrite rules immediately only when `init` has already run, otherwise it schedules the existing `Plugin::refreshInternalDelistRewriteRules()` method for `init` priority 20.

This preserves the existing rewrite/flush behavior while making migrations safe during WP-CLI bootstrap.

Closes #49