### PR TITLE
Forward sync 3.1 into 3.2

### DIFF
--- a/.github/BRANCHING.md
+++ b/.github/BRANCHING.md
@@ -6,7 +6,7 @@ This repository currently develops two active version lines in parallel. The bra
 
 - `3.1` is the current stable development and maintenance line.
 - `master` represents the current stable code line.
-- Changes merged into `3.1` are allowed to flow directly into `master`.
+- Changes merged into `3.1` flow directly into `master`.
 - While both version lines are active, every change merged into `3.1` must also be forward-synced into `3.2`.
 - `3.2` is based on `3.1` and adds the upcoming `3.2.0` WooCommerce and fraud integration work.
 
@@ -29,14 +29,18 @@ Branch synchronization is not a release operation.
 - Do not create or publish a `3.1.6` tag/release unless explicitly requested.
 - The same rule applies to `3.2.0`: development on the `3.2` branch does not itself authorize tagging or publishing a release.
 
-## Pull requests and conflicts
+## Automated synchronization and conflicts
 
-- Stable promotion should use normal pull requests from `3.1` to `master` when synchronization is needed.
-- Forward synchronization should use normal pull requests from `3.1` to `3.2` when synchronization is needed.
-- Never force-merge or silently discard conflicting changes.
-- Resolve conflicts explicitly and preserve both the stable-line fix and valid `3.2` development work.
-- A merge commit making `master` technically one commit ahead of `3.1` is acceptable when there is no file-content difference between the stable branches.
+Synchronization from `3.1` is handled by GitHub Actions rather than recurring synchronization pull requests.
+
+- A push to `3.1` triggers synchronization into both `master` and `3.2`.
+- Each target is processed independently so a failure for one target does not cancel the other target.
+- If a target already contains all commits from `3.1`, that target is left unchanged.
+- When the merge is clean, the Action creates a normal merge commit and pushes it to the target branch.
+- Never force-push, force-merge, silently discard changes, or automatically resolve conflicts.
+- A merge conflict or a branch-protection rejection must make that target's Action job fail visibly and require explicit intervention.
+- Manual `workflow_dispatch` remains available to retry synchronization after a problem has been resolved.
 
 ## Development direction
 
-`3.1` remains the stable maintenance base while `3.2` develops the broader WooCommerce/fraud architecture. Features that belong specifically to the new 3.2 architecture should target `3.2`. Fixes or stable improvements that should also exist in the current stable code should normally target `3.1` first and then be forward-synced.
+`3.1` remains the stable maintenance base while `3.2` develops the broader WooCommerce/fraud architecture. Features that belong specifically to the new 3.2 architecture should target `3.2`. Fixes or stable improvements that should also exist in the current stable code should normally target `3.1` first and then be forward-synced automatically.

--- a/.github/BRANCHING.md
+++ b/.github/BRANCHING.md
@@ -1,0 +1,42 @@
+# Branch strategy
+
+This repository currently develops two active version lines in parallel. The branch relationships below are intentional and should be preserved by future work.
+
+## Current branch model
+
+- `3.1` is the current stable development and maintenance line.
+- `master` represents the current stable code line.
+- Changes merged into `3.1` are allowed to flow directly into `master`.
+- While both version lines are active, every change merged into `3.1` must also be forward-synced into `3.2`.
+- `3.2` is based on `3.1` and adds the upcoming `3.2.0` WooCommerce and fraud integration work.
+
+In practical terms:
+
+```text
+3.1 -> master
+3.1 -> 3.2
+3.2 = 3.1 + 3.2.0 development
+```
+
+`3.2` must not drift behind `3.1`. Maintenance fixes and stable changes belong in `3.1` first when they apply to both lines, then move forward into `3.2`.
+
+## Releases and tags
+
+Branch synchronization is not a release operation.
+
+- Do not create a Git tag or GitHub release merely because `3.1` is merged into `master` or forward-synced into `3.2`.
+- The code may identify itself as `3.1.6` without a corresponding published `3.1.6` tag.
+- Do not create or publish a `3.1.6` tag/release unless explicitly requested.
+- The same rule applies to `3.2.0`: development on the `3.2` branch does not itself authorize tagging or publishing a release.
+
+## Pull requests and conflicts
+
+- Stable promotion should use normal pull requests from `3.1` to `master` when synchronization is needed.
+- Forward synchronization should use normal pull requests from `3.1` to `3.2` when synchronization is needed.
+- Never force-merge or silently discard conflicting changes.
+- Resolve conflicts explicitly and preserve both the stable-line fix and valid `3.2` development work.
+- A merge commit making `master` technically one commit ahead of `3.1` is acceptable when there is no file-content difference between the stable branches.
+
+## Development direction
+
+`3.1` remains the stable maintenance base while `3.2` develops the broader WooCommerce/fraud architecture. Features that belong specifically to the new 3.2 architecture should target `3.2`. Fixes or stable improvements that should also exist in the current stable code should normally target `3.1` first and then be forward-synced.

--- a/.github/workflows/forward-sync-3.1-to-3.2.yml
+++ b/.github/workflows/forward-sync-3.1-to-3.2.yml
@@ -1,4 +1,4 @@
-name: Forward sync 3.1 to 3.2
+name: Forward sync 3.1
 
 on:
   push:
@@ -11,9 +11,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  open-sync-pr:
-    name: Open 3.1 to 3.2 sync PR
+  open-sync-prs:
+    name: Open 3.1 forward-sync PRs
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        base:
+          - master
+          - '3.2'
 
     steps:
       - name: Check and open forward-sync pull request
@@ -23,7 +29,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const head = '3.1';
-            const base = '3.2';
+            const base = '${{ matrix.base }}';
 
             const comparison = await github.rest.repos.compareCommitsWithBasehead({
               owner,
@@ -46,7 +52,7 @@ jobs:
             });
 
             if (existing.data.length > 0) {
-              core.info(`Forward-sync PR already open: #${existing.data[0].number}`);
+              core.info(`Forward-sync PR already open for ${base}: #${existing.data[0].number}`);
               return;
             }
 
@@ -57,12 +63,12 @@ jobs:
               base,
               title: `Forward sync ${head} into ${base}`,
               body: [
-                'Automated forward-sync PR for the parallel 3.1/3.2 development period.',
+                'Automated forward-sync PR while 3.1 is the current stable line.',
                 '',
                 `This PR carries changes merged into \`${head}\` forward into \`${base}\`.`,
                 '',
-                'Conflicts must be resolved explicitly. This workflow never force-merges or silently resolves conflicts.',
+                'No release tag is created. Conflicts must be resolved explicitly; this workflow never force-merges or silently resolves conflicts.',
               ].join('\n'),
             });
 
-            core.info(`Created forward-sync PR #${created.data.number}.`);
+            core.info(`Created forward-sync PR #${created.data.number} for ${base}.`);

--- a/.github/workflows/forward-sync-3.1-to-3.2.yml
+++ b/.github/workflows/forward-sync-3.1-to-3.2.yml
@@ -7,68 +7,46 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write
+
+concurrency:
+  group: forward-sync-3.1
+  cancel-in-progress: false
 
 jobs:
-  open-sync-prs:
-    name: Open 3.1 forward-sync PRs
+  sync:
+    name: Sync 3.1 into ${{ matrix.base }}
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         base:
           - master
           - '3.2'
 
     steps:
-      - name: Check and open forward-sync pull request
-        uses: actions/github-script@v7
+      - name: Check out target branch
+        uses: actions/checkout@v4
         with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const head = '3.1';
-            const base = '${{ matrix.base }}';
+          ref: ${{ matrix.base }}
+          fetch-depth: 0
 
-            const comparison = await github.rest.repos.compareCommitsWithBasehead({
-              owner,
-              repo,
-              basehead: `${base}...${head}`,
-            });
+      - name: Merge 3.1 into target
+        shell: bash
+        run: |
+          set -euo pipefail
 
-            if (comparison.data.ahead_by === 0) {
-              core.info(`${base} already contains all commits from ${head}.`);
-              return;
-            }
+          target='${{ matrix.base }}'
+          git fetch origin 3.1
 
-            const existing = await github.rest.pulls.list({
-              owner,
-              repo,
-              state: 'open',
-              head: `${owner}:${head}`,
-              base,
-              per_page: 100,
-            });
+          if git merge-base --is-ancestor origin/3.1 HEAD; then
+            echo "${target} already contains all commits from 3.1."
+            exit 0
+          fi
 
-            if (existing.data.length > 0) {
-              core.info(`Forward-sync PR already open for ${base}: #${existing.data[0].number}`);
-              return;
-            }
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-            const created = await github.rest.pulls.create({
-              owner,
-              repo,
-              head,
-              base,
-              title: `Forward sync ${head} into ${base}`,
-              body: [
-                'Automated forward-sync PR while 3.1 is the current stable line.',
-                '',
-                `This PR carries changes merged into \`${head}\` forward into \`${base}\`.`,
-                '',
-                'No release tag is created. Conflicts must be resolved explicitly; this workflow never force-merges or silently resolves conflicts.',
-              ].join('\n'),
-            });
-
-            core.info(`Created forward-sync PR #${created.data.number} for ${base}.`);
+          git merge --no-ff -m "Forward sync 3.1 into ${target}" origin/3.1
+          git push origin "HEAD:${target}"

--- a/.github/workflows/forward-sync-3.1-to-3.2.yml
+++ b/.github/workflows/forward-sync-3.1-to-3.2.yml
@@ -1,0 +1,68 @@
+name: Forward sync 3.1 to 3.2
+
+on:
+  push:
+    branches:
+      - '3.1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-sync-pr:
+    name: Open 3.1 to 3.2 sync PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check and open forward-sync pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = '3.1';
+            const base = '3.2';
+
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${base}...${head}`,
+            });
+
+            if (comparison.data.ahead_by === 0) {
+              core.info(`${base} already contains all commits from ${head}.`);
+              return;
+            }
+
+            const existing = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${head}`,
+              base,
+              per_page: 100,
+            });
+
+            if (existing.data.length > 0) {
+              core.info(`Forward-sync PR already open: #${existing.data[0].number}`);
+              return;
+            }
+
+            const created = await github.rest.pulls.create({
+              owner,
+              repo,
+              head,
+              base,
+              title: `Forward sync ${head} into ${base}`,
+              body: [
+                'Automated forward-sync PR for the parallel 3.1/3.2 development period.',
+                '',
+                `This PR carries changes merged into \`${head}\` forward into \`${base}\`.`,
+                '',
+                'Conflicts must be resolved explicitly. This workflow never force-merges or silently resolves conflicts.',
+              ].join('\n'),
+            });
+
+            core.info(`Created forward-sync PR #${created.data.number}.`);

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,34 @@
+name: WordPress Plugin Check
+
+on:
+  pull_request:
+    branches:
+      - '3.1'
+      - '3.2'
+  push:
+    branches:
+      - '3.1'
+      - '3.2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wordpress-plugin-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-check:
+    name: WordPress Plugin Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out plugin
+        uses: actions/checkout@v4
+
+      - name: Run WordPress Plugin Check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: './'
+          strict: false

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -3,10 +3,12 @@ name: WordPress Plugin Check
 on:
   pull_request:
     branches:
+      - 'master'
       - '3.1'
       - '3.2'
   push:
     branches:
+      - 'master'
       - '3.1'
       - '3.2'
   workflow_dispatch:


### PR DESCRIPTION
Manual recovery forward-sync for the currently active branch model.

- Carries the current `3.1` stable line into `3.2`.
- `3.2` is currently 9 commits behind `3.1`.
- The existing forward-sync workflow failed while trying to create this PR automatically, so issue #31 remains open until the automation itself is verified.
- No tag or release is created.
- Conflicts, if any, must be resolved explicitly.

Related to #31.