### PR TITLE
Fix Plugin Check production identity

### DIFF
--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: wordpress-plugin-check-${{ github.workflow }}-${{ github.ref }}
@@ -33,4 +34,9 @@ jobs:
         uses: wordpress/plugin-check-action@v1
         with:
           build-dir: './'
+          slug: 'tornevall-networks-dnsbl-implementation'
+          exclude-files: |
+            .gitignore
+          exclude-directories: |
+            .github
           strict: false


### PR DESCRIPTION
Closes #53.

## Summary

- passes the published WordPress.org slug `tornevall-networks-dnsbl-implementation` explicitly to Plugin Check
- excludes repository-only `.gitignore` and `.github` content from the production plugin scan
- grants `pull-requests: write` so the action can post/update its Plugin Check PR comment
- keeps `strict: false`, so warnings remain visible while real Plugin Check errors still fail CI

This removes the checkout-directory-derived `tornevall-wp-dnsbl` identity noise so remaining failures are actionable plugin findings.