### PR TITLE
Pair DNSBL directly with Tools and rotate existing tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the DNSBL plugin should be documented in this file.
 
+## Unreleased
+
+### Added
+- Added the optional server-side `tornevall_dnsbl_managed_api_token` filter so a separate WordPress integration can provide a site-specific DNSBL credential without duplicating DNSBL functionality.
+- Added handling for both empty and previously nonexistent legacy Tools-token options, so fresh installations can consume a managed credential as the final fallback.
+
+### Security
+- Explicit DNSBL plugin token settings keep priority over managed credentials.
+- Managed credentials are resolved server-side only and are not rendered into browser markup, JavaScript, diagnostics or logs by the bridge.
+
 ## 3.1.6 - 2026-08-19
 
 ### Added
@@ -77,7 +87,7 @@ All notable changes to the DNSBL plugin should be documented in this file.
 - DNSBL write/check auth diagnostics now distinguish wrong-token-type and inactive-admin-key cases from truly invalid/revoked DNSBL tokens.
 - Removal Turnstile verification is now skipped for checker-only/background pre-check requests and enforced on actual write submissions, which fixes false `Verification failed. Please try again.` messages.
 - CIDR delist no longer depends on the originally checked single IP being the only anchor for the requested block; the final submit now accepts a completed local CIDR scan ticket for the exact Advanced-range scope instead.
-- CIDR delete timeouts now surface as an explicit timeout/warning state instead of the older generic “failed chunk” message when WordPress only lost the HTTP response while Tools may still have completed already-submitted deletes.
+- CIDR delete timeouts now surface as an explicit timeout/warning state instead of the older generic "failed chunk" message when WordPress only lost the HTTP response while Tools may still have completed already-submitted deletes.
 - The public checker can now be reused immediately after a completed lookup: the IP field no longer stays terminally locked after a listed result, and a dedicated **Reset** button now clears checker/CIDR/background state so users can start over without refreshing the page.
 - Reset/input changes now invalidate older checker/CIDR async callbacks more aggressively, so stale background responses from a previous search are less likely to repaint the form after the user has already started over.
 
@@ -195,13 +205,13 @@ All notable changes to the DNSBL plugin should be documented in this file.
 
 ### Notes
 - The local tag readme preserves only a link to the historical release post, not detailed bullet notes.
-- Historical release reference: <https://www.tornevall.net/2018/07/17/dnsbl-for-wordpress-2-0-1-changelog/>
+- Historical release reference: <https://www.tornevall.net/2018/07/17/dnsbl-for-wordpress-2-0-1-changelog/>.
 
 ## 2.0.0
 
 ### Notes
 - The local tag readme preserves only a link to the historical release post, not detailed bullet notes.
-- Historical release reference: <https://www.tornevall.net/2018/07/17/dnsbl-for-wordpress-2-0-0-changelog/>
+- Historical release reference: <https://www.tornevall.net/2018/07/17/dnsbl-for-wordpress-2-0-0-changelog/>.
 
 ## 1.1.1
 

--- a/docs/managed-tools-token.md
+++ b/docs/managed-tools-token.md
@@ -1,0 +1,36 @@
+# Managed Tools DNSBL token bridge
+
+The DNSBL plugin remains fully standalone and keeps its own explicit token settings as the highest priority.
+
+An optional server-side integration may provide a site-specific DNSBL credential through:
+
+```php
+add_filter('tornevall_dnsbl_managed_api_token', function ($token) {
+    return $managedToken;
+});
+```
+
+The bridge is intended for integrations such as Tornevall Tools for WordPress after a WordPress administrator explicitly connects and authorizes the site in Tools.
+
+## Priority
+
+The existing DNSBL token resolution order is preserved. The managed token feeds only the final Tools fallback and is therefore used only after the plugin's own configured token values are empty.
+
+1. Visible DNSBL write token.
+2. Existing legacy removal token fallback, when still present on an upgraded installation.
+3. Existing stored legacy Tools token fallback.
+4. `tornevall_dnsbl_managed_api_token` supplied by another server-side plugin.
+
+This means a manually configured DNSBL token always remains the explicit override.
+
+## Security
+
+- The DNSBL plugin does not request or discover Tools account tokens itself.
+- The filter is server-side only. The managed credential must not be rendered into HTML, browser JavaScript, diagnostics, screenshots or logs.
+- The provider is responsible for obtaining the credential through an explicit authorization flow.
+- The DNSBL plugin continues to perform normal token-info and write permission checks against the effective resolved token.
+- If no provider is installed, the filter returns an empty value and the DNSBL plugin behaves exactly as before.
+
+## Tornevall Tools for WordPress
+
+Tornevall Tools for WordPress can use the Tools WordPress pairing API to obtain a dedicated site-specific DNSBL credential after the logged-in Tools user approves the connection. It then supplies that credential through this filter without copying DNSBL implementation into the Tools-for-WordPress plugin.

--- a/docs/tools-pairing.md
+++ b/docs/tools-pairing.md
@@ -1,0 +1,47 @@
+# Direct Tornevall Tools pairing
+
+The DNSBL plugin can authorize directly against Tornevall Tools without requiring an administrator to copy a DNSBL token manually.
+
+## Flow
+
+1. A WordPress administrator starts the connection from the DNSBL settings page.
+2. The plugin creates a short-lived pairing request at `POST /api/integrations/wordpress/device` and requests only the `dnsbl` service.
+3. The administrator is redirected to Tornevall Tools and signs in with the normal Tools account session.
+4. Tools lists active DNSBL tokens owned by that user using safe metadata only. Existing raw token values are never displayed.
+5. The administrator selects a token and chooses whether to rotate/reuse it or create a separate site token.
+6. After approval, WordPress receives the callback and exchanges the high-entropy device code once through `POST /api/integrations/wordpress/token`.
+7. The returned DNSBL credential is stored directly in the canonical `tornevall_dnsbl_write_token` WordPress option.
+
+## Existing-token rotation
+
+Rotation is the default choice for a selected non-admin DNSBL token.
+
+Tools preserves the existing token database id, permissions and delete guardrails, generates a new secret and invalidates the previous secret immediately. Only the newly generated value is returned through the one-time server-to-server exchange.
+
+Any other client still using the old secret must be updated after rotation. The Tools approval page displays this warning before the user approves the operation.
+
+## Separate site token
+
+The Tools approval page also allows the selected token to remain unchanged. In that mode Tools creates a new non-admin DNSBL token with the selected token's effective permissions and returns that new site credential instead.
+
+## Admin tokens
+
+Admin DNSBL tokens are never installed directly in WordPress and are never rotated into an external WordPress installation. If an admin token is selected, Tools creates a non-admin token carrying the effective DNSBL permissions instead.
+
+## Authentication model
+
+This integration uses a device-style authorization flow rather than a separate OAuth client secret.
+
+- The Tools browser session authenticates the user.
+- Approval is explicit.
+- The raw device code has high entropy and is stored only temporarily by the WordPress plugin.
+- Tools stores only the device-code hash.
+- The approved credential bundle is encrypted while waiting for exchange.
+- Credential exchange is server-to-server and single-use.
+- The plugin validates the Tools authorization host, its WordPress nonce, the local pairing state and the returned user code before exchanging credentials.
+
+## Compatibility with Tornevall Tools for WordPress
+
+The standalone DNSBL plugin can pair with Tools directly. It also continues to support the `tornevall_dnsbl_managed_api_token` server-side filter so Tornevall Tools for WordPress may provide a managed fallback credential when no explicit DNSBL token is configured locally.
+
+An explicitly configured DNSBL write token remains the highest-priority credential.

--- a/includes/class-dnsbl-managed-tools-token.php
+++ b/includes/class-dnsbl-managed-tools-token.php
@@ -23,11 +23,12 @@ class ManagedToolsToken
 
     public static function registerHooks(): void
     {
-        add_filter('option_' . self::LEGACY_TOOLS_TOKEN_OPTION, [self::class, 'resolve'], 20, 2);
+        add_filter('option_' . self::LEGACY_TOOLS_TOKEN_OPTION, [self::class, 'resolve'], 20, 1);
+        add_filter('default_option_' . self::LEGACY_TOOLS_TOKEN_OPTION, [self::class, 'resolve'], 20, 1);
     }
 
     /**
-     * @param mixed $storedValue Stored legacy Tools token value.
+     * @param mixed $storedValue Stored legacy Tools token value or default.
      * @return mixed
      */
     public static function resolve($storedValue)
@@ -41,7 +42,7 @@ class ManagedToolsToken
          *
          * The value must never be rendered into browser markup or JavaScript.
          * Explicit DNSBL plugin token settings always take precedence because
-         * this filter is attached only to the final legacy Tools fallback.
+         * this bridge feeds only the final legacy Tools fallback.
          *
          * @param string $token Managed token candidate. Empty by default.
          */

--- a/includes/class-dnsbl-managed-tools-token.php
+++ b/includes/class-dnsbl-managed-tools-token.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tornevall\Networks\DNSBL;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Lets another server-side WordPress integration provide a DNSBL credential
+ * without coupling this plugin to that integration.
+ */
+class ManagedToolsToken
+{
+    /**
+     * Legacy Tools token option used as the last fallback by Plugin::apiToken().
+     *
+     * Filtering this option preserves the existing priority order:
+     * explicit write token, legacy removal token, stored legacy Tools token,
+     * then an externally managed token.
+     */
+    private const LEGACY_TOOLS_TOKEN_OPTION = 'tornevall_dnsbl_tools_token';
+
+    public static function registerHooks(): void
+    {
+        add_filter('option_' . self::LEGACY_TOOLS_TOKEN_OPTION, [self::class, 'resolve'], 20, 2);
+    }
+
+    /**
+     * @param mixed $storedValue Stored legacy Tools token value.
+     * @return mixed
+     */
+    public static function resolve($storedValue)
+    {
+        if (is_scalar($storedValue) && trim((string)$storedValue) !== '') {
+            return $storedValue;
+        }
+
+        /**
+         * Supply a managed DNSBL API token from another server-side plugin.
+         *
+         * The value must never be rendered into browser markup or JavaScript.
+         * Explicit DNSBL plugin token settings always take precedence because
+         * this filter is attached only to the final legacy Tools fallback.
+         *
+         * @param string $token Managed token candidate. Empty by default.
+         */
+        $managed = apply_filters('tornevall_dnsbl_managed_api_token', '');
+
+        if (!is_scalar($managed)) {
+            return $storedValue;
+        }
+
+        $managed = trim((string)$managed);
+        return $managed !== '' ? $managed : $storedValue;
+    }
+}

--- a/includes/class-dnsbl-tools-pairing.php
+++ b/includes/class-dnsbl-tools-pairing.php
@@ -42,7 +42,7 @@ class ToolsPairing
 
         $response = self::postTools('/api/integrations/wordpress/device', [
             'site_name' => get_bloginfo('name') . ' - Tornevall DNSBL',
-            'site_url' => home_url('/'),
+            'site_url' => site_url('/'),
             'callback_url' => $callbackUrl,
             'requested_services' => ['dnsbl'],
         ]);
@@ -159,19 +159,17 @@ class ToolsPairing
             self::START_ACTION
         );
         $hasToken = Plugin::writeTokenSet();
+        $description = $hasToken
+            ? __('Authorize with your Tools account to select this or another DNSBL token. By default Tools rotates the selected existing token and installs its new value here automatically; you can choose a separate site token on the approval page instead.', 'tornevall-networks-dnsbl-implementation')
+            : __('Authorize with your Tools account to select an existing DNSBL token. By default Tools rotates that token and installs its new value here automatically; you can choose a separate site token on the approval page instead.', 'tornevall-networks-dnsbl-implementation');
+        $buttonLabel = $hasToken
+            ? __('Connect / rotate token via Tools', 'tornevall-networks-dnsbl-implementation')
+            : __('Connect to Tools and select token', 'tornevall-networks-dnsbl-implementation');
 
         echo '<div class="notice notice-info" style="padding:14px 18px;">';
         echo '<p><strong>' . esc_html__('Connect DNSBL directly to Tornevall Tools', 'tornevall-networks-dnsbl-implementation') . '</strong></p>';
-        echo '<p>' . esc_html__(
-            $hasToken
-                ? 'Authorize with your Tools account to select this or another DNSBL token. By default Tools rotates the selected existing token and installs its new value here automatically; you can choose a separate site token on the approval page instead.'
-                : 'Authorize with your Tools account to select an existing DNSBL token. By default Tools rotates that token and installs its new value here automatically; you can choose a separate site token on the approval page instead.',
-            'tornevall-networks-dnsbl-implementation'
-        ) . '</p>';
-        echo '<p><a class="button button-primary" href="' . esc_url($url) . '">' . esc_html__(
-            $hasToken ? 'Connect / rotate token via Tools' : 'Connect to Tools and select token',
-            'tornevall-networks-dnsbl-implementation'
-        ) . '</a></p>';
+        echo '<p>' . esc_html($description) . '</p>';
+        echo '<p><a class="button button-primary" href="' . esc_url($url) . '">' . esc_html($buttonLabel) . '</a></p>';
         echo '<p class="description">' . esc_html(sprintf(
             __('Authorization host: %s. No token value is displayed in the browser.', 'tornevall-networks-dnsbl-implementation'),
             Plugin::toolsBaseUrl()
@@ -192,7 +190,7 @@ class ToolsPairing
         }
 
         $message = isset($_GET['tornevall_dnsbl_pairing_message'])
-            ? sanitize_text_field(rawurldecode(wp_unslash((string)$_GET['tornevall_dnsbl_pairing_message'])))
+            ? sanitize_text_field(wp_unslash((string)$_GET['tornevall_dnsbl_pairing_message']))
             : '';
         if ($message === '') {
             $message = $notice === 'connected'
@@ -205,8 +203,8 @@ class ToolsPairing
     }
 
     /**
-     * @param string               $path API path.
-     * @param array<string,mixed>  $payload Request payload.
+     * @param string              $path API path.
+     * @param array<string,mixed> $payload Request payload.
      * @return array<string,mixed>|WP_Error
      */
     private static function postTools(string $path, array $payload)
@@ -282,7 +280,7 @@ class ToolsPairing
         $args = [
             'page' => 'tornevallDnsblMenu',
             'tornevall_dnsbl_pairing' => sanitize_key($notice),
-            'tornevall_dnsbl_pairing_message' => rawurlencode(sanitize_text_field($message)),
+            'tornevall_dnsbl_pairing_message' => sanitize_text_field($message),
         ];
         if ($credentialMode !== '') {
             $args['tornevall_dnsbl_credential_mode'] = sanitize_key($credentialMode);

--- a/includes/class-dnsbl-tools-pairing.php
+++ b/includes/class-dnsbl-tools-pairing.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Tornevall\Networks\DNSBL;
+
+use WP_Error;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Direct device-style authorization between this DNSBL plugin and Tools.
+ *
+ * The browser is only used for the logged-in Tools approval step. The raw
+ * device code and returned DNSBL credential stay server-side in WordPress.
+ */
+class ToolsPairing
+{
+    private const START_ACTION = 'tornevall_dnsbl_tools_pairing_start';
+    private const COMPLETE_ACTION = 'tornevall_dnsbl_tools_pairing_complete';
+    private const TRANSIENT_PREFIX = 'tornevall_dnsbl_tools_pairing_';
+    private const MAX_PAIRING_TTL = 600;
+
+    public static function registerHooks(): void
+    {
+        add_action('admin_post_' . self::START_ACTION, [self::class, 'start']);
+        add_action('admin_post_' . self::COMPLETE_ACTION, [self::class, 'complete']);
+        add_action('admin_notices', [self::class, 'renderAdminNotice']);
+    }
+
+    public static function start(): void
+    {
+        self::requireAdmin();
+        check_admin_referer(self::START_ACTION);
+
+        $state = wp_generate_password(48, false, false);
+        $callbackUrl = add_query_arg([
+            'action' => self::COMPLETE_ACTION,
+            'pair_state' => $state,
+            '_wpnonce' => wp_create_nonce(self::COMPLETE_ACTION),
+        ], admin_url('admin-post.php'));
+
+        $response = self::postTools('/api/integrations/wordpress/device', [
+            'site_name' => get_bloginfo('name') . ' - Tornevall DNSBL',
+            'site_url' => home_url('/'),
+            'callback_url' => $callbackUrl,
+            'requested_services' => ['dnsbl'],
+        ]);
+
+        if (is_wp_error($response)) {
+            self::redirectWithNotice('error', $response->get_error_message());
+        }
+
+        $deviceCode = isset($response['device_code']) ? trim((string)$response['device_code']) : '';
+        $userCode = isset($response['user_code']) ? sanitize_text_field((string)$response['user_code']) : '';
+        $verificationUrl = isset($response['verification_uri_complete'])
+            ? esc_url_raw((string)$response['verification_uri_complete'])
+            : '';
+        $expiresIn = isset($response['expires_in']) ? absint($response['expires_in']) : self::MAX_PAIRING_TTL;
+
+        if ($deviceCode === '' || $userCode === '' || !self::isToolsAuthorizationUrl($verificationUrl)) {
+            self::redirectWithNotice('error', __('Tools returned an invalid DNSBL pairing response.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        set_transient(self::transientKey(), [
+            'device_code' => $deviceCode,
+            'user_code' => $userCode,
+            'state_hash' => hash('sha256', $state),
+        ], max(60, min(self::MAX_PAIRING_TTL, $expiresIn)));
+
+        wp_redirect($verificationUrl);
+        exit;
+    }
+
+    public static function complete(): void
+    {
+        self::requireAdmin();
+        check_admin_referer(self::COMPLETE_ACTION);
+
+        $pairing = get_transient(self::transientKey());
+        $pairing = is_array($pairing) ? $pairing : [];
+        $state = isset($_GET['pair_state']) ? sanitize_text_field(wp_unslash((string)$_GET['pair_state'])) : '';
+        $userCode = isset($_GET['user_code']) ? sanitize_text_field(wp_unslash((string)$_GET['user_code'])) : '';
+        $connectionState = isset($_GET['tools_connection'])
+            ? sanitize_key(wp_unslash((string)$_GET['tools_connection']))
+            : (isset($_GET['ttfw_connection']) ? sanitize_key(wp_unslash((string)$_GET['ttfw_connection'])) : '');
+
+        if (
+            empty($pairing['device_code'])
+            || empty($pairing['user_code'])
+            || empty($pairing['state_hash'])
+            || $state === ''
+            || !hash_equals((string)$pairing['state_hash'], hash('sha256', $state))
+            || $userCode === ''
+            || !hash_equals((string)$pairing['user_code'], $userCode)
+        ) {
+            delete_transient(self::transientKey());
+            self::redirectWithNotice('error', __('The DNSBL Tools pairing session is missing, expired, or does not match this callback.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        if ($connectionState === 'denied') {
+            delete_transient(self::transientKey());
+            self::redirectWithNotice('denied', __('The DNSBL Tools connection was denied.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        if ($connectionState !== 'complete') {
+            delete_transient(self::transientKey());
+            self::redirectWithNotice('error', __('Tools returned an unknown DNSBL pairing state.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        $response = self::postTools('/api/integrations/wordpress/token', [
+            'device_code' => (string)$pairing['device_code'],
+        ]);
+        delete_transient(self::transientKey());
+
+        if (is_wp_error($response)) {
+            self::redirectWithNotice('error', $response->get_error_message());
+        }
+
+        $dnsbl = isset($response['services']['dnsbl']) && is_array($response['services']['dnsbl'])
+            ? $response['services']['dnsbl']
+            : [];
+        $token = isset($dnsbl['token']) && is_scalar($dnsbl['token'])
+            ? Admin::sanitizeDnsblWriteToken((string)$dnsbl['token'])
+            : '';
+
+        if (empty($dnsbl['available']) || $token === '') {
+            $reason = isset($dnsbl['reason']) ? sanitize_key((string)$dnsbl['reason']) : '';
+            $message = $reason === 'no_active_dnsbl_token'
+                ? __('The connected Tools account has no active DNSBL token available.', 'tornevall-networks-dnsbl-implementation')
+                : __('Tools approved the connection but returned no usable DNSBL credential.', 'tornevall-networks-dnsbl-implementation');
+            self::redirectWithNotice('error', $message);
+        }
+
+        update_option('tornevall_dnsbl_write_token', $token, false);
+
+        $credentialMode = isset($dnsbl['credential_mode'])
+            ? sanitize_key((string)$dnsbl['credential_mode'])
+            : '';
+
+        self::redirectWithNotice(
+            'connected',
+            self::successMessage($credentialMode),
+            $credentialMode
+        );
+    }
+
+    public static function renderAdminNotice(): void
+    {
+        if (!current_user_can('manage_options') || !self::isDnsblSettingsPage()) {
+            return;
+        }
+
+        self::renderResultNotice();
+
+        $mode = Plugin::toolsMode();
+        $url = wp_nonce_url(
+            admin_url('admin-post.php?action=' . self::START_ACTION),
+            self::START_ACTION
+        );
+        $hasToken = Plugin::writeTokenSet();
+
+        echo '<div class="notice notice-info" style="padding:14px 18px;">';
+        echo '<p><strong>' . esc_html__('Connect DNSBL directly to Tornevall Tools', 'tornevall-networks-dnsbl-implementation') . '</strong></p>';
+        echo '<p>' . esc_html__(
+            $hasToken
+                ? 'Authorize with your Tools account to select this or another DNSBL token. By default Tools rotates the selected existing token and installs its new value here automatically; you can choose a separate site token on the approval page instead.'
+                : 'Authorize with your Tools account to select an existing DNSBL token. By default Tools rotates that token and installs its new value here automatically; you can choose a separate site token on the approval page instead.',
+            'tornevall-networks-dnsbl-implementation'
+        ) . '</p>';
+        echo '<p><a class="button button-primary" href="' . esc_url($url) . '">' . esc_html__(
+            $hasToken ? 'Connect / rotate token via Tools' : 'Connect to Tools and select token',
+            'tornevall-networks-dnsbl-implementation'
+        ) . '</a></p>';
+        echo '<p class="description">' . esc_html(sprintf(
+            __('Authorization host: %s. No token value is displayed in the browser.', 'tornevall-networks-dnsbl-implementation'),
+            Plugin::toolsBaseUrl()
+        )) . '</p>';
+        if ($mode === 'dev') {
+            echo '<p class="description"><strong>' . esc_html__('Development mode is active.', 'tornevall-networks-dnsbl-implementation') . '</strong></p>';
+        }
+        echo '</div>';
+    }
+
+    private static function renderResultNotice(): void
+    {
+        $notice = isset($_GET['tornevall_dnsbl_pairing'])
+            ? sanitize_key(wp_unslash((string)$_GET['tornevall_dnsbl_pairing']))
+            : '';
+        if (!in_array($notice, ['connected', 'denied', 'error'], true)) {
+            return;
+        }
+
+        $message = isset($_GET['tornevall_dnsbl_pairing_message'])
+            ? sanitize_text_field(rawurldecode(wp_unslash((string)$_GET['tornevall_dnsbl_pairing_message'])))
+            : '';
+        if ($message === '') {
+            $message = $notice === 'connected'
+                ? __('The DNSBL Tools connection was updated.', 'tornevall-networks-dnsbl-implementation')
+                : __('The DNSBL Tools connection could not be completed.', 'tornevall-networks-dnsbl-implementation');
+        }
+
+        $class = $notice === 'connected' ? 'notice-success' : ($notice === 'denied' ? 'notice-warning' : 'notice-error');
+        echo '<div class="notice ' . esc_attr($class) . ' is-dismissible"><p>' . esc_html($message) . '</p></div>';
+    }
+
+    /**
+     * @param string               $path API path.
+     * @param array<string,mixed>  $payload Request payload.
+     * @return array<string,mixed>|WP_Error
+     */
+    private static function postTools(string $path, array $payload)
+    {
+        $url = untrailingslashit(Plugin::toolsBaseUrl()) . '/' . ltrim($path, '/');
+        $response = wp_remote_post($url, [
+            'timeout' => 20,
+            'redirection' => 0,
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+            'body' => wp_json_encode($payload),
+        ]);
+
+        if (is_wp_error($response)) {
+            return new WP_Error('tornevall_dnsbl_tools_pairing_transport', __('Could not reach Tornevall Tools.', 'tornevall-networks-dnsbl-implementation'));
+        }
+
+        $status = (int)wp_remote_retrieve_response_code($response);
+        $body = json_decode((string)wp_remote_retrieve_body($response), true);
+        $body = is_array($body) ? $body : [];
+
+        if ($status < 200 || $status >= 300) {
+            $message = isset($body['message']) && is_scalar($body['message'])
+                ? sanitize_text_field((string)$body['message'])
+                : __('Tornevall Tools rejected the DNSBL pairing request.', 'tornevall-networks-dnsbl-implementation');
+            return new WP_Error('tornevall_dnsbl_tools_pairing_http', $message, ['status' => $status]);
+        }
+
+        return $body;
+    }
+
+    private static function isToolsAuthorizationUrl(string $url): bool
+    {
+        if (!wp_http_validate_url($url)) {
+            return false;
+        }
+
+        $expectedHost = strtolower((string)wp_parse_url(Plugin::toolsBaseUrl(), PHP_URL_HOST));
+        return strtolower((string)wp_parse_url($url, PHP_URL_SCHEME)) === 'https'
+            && strtolower((string)wp_parse_url($url, PHP_URL_HOST)) === $expectedHost;
+    }
+
+    private static function isDnsblSettingsPage(): bool
+    {
+        $page = isset($_GET['page']) ? sanitize_key(wp_unslash((string)$_GET['page'])) : '';
+        return $page === 'tornevalldnsblmenu';
+    }
+
+    private static function transientKey(): string
+    {
+        return self::TRANSIENT_PREFIX . get_current_user_id();
+    }
+
+    private static function successMessage(string $credentialMode): string
+    {
+        if ($credentialMode === 'rotated_existing') {
+            return __('The selected existing DNSBL token was rotated and its new value is now configured in this plugin. The previous token value is no longer valid.', 'tornevall-networks-dnsbl-implementation');
+        }
+        if ($credentialMode === 'copied_from_admin') {
+            return __('Tools created a non-admin DNSBL credential from the selected admin permissions and configured it in this plugin. The admin token itself was not changed.', 'tornevall-networks-dnsbl-implementation');
+        }
+        if ($credentialMode === 'created_copy') {
+            return __('Tools created a separate DNSBL site token and configured it in this plugin. The selected existing token was not changed.', 'tornevall-networks-dnsbl-implementation');
+        }
+
+        return __('The DNSBL credential returned by Tools is now configured in this plugin.', 'tornevall-networks-dnsbl-implementation');
+    }
+
+    private static function redirectWithNotice(string $notice, string $message, string $credentialMode = ''): void
+    {
+        $args = [
+            'page' => 'tornevallDnsblMenu',
+            'tornevall_dnsbl_pairing' => sanitize_key($notice),
+            'tornevall_dnsbl_pairing_message' => rawurlencode(sanitize_text_field($message)),
+        ];
+        if ($credentialMode !== '') {
+            $args['tornevall_dnsbl_credential_mode'] = sanitize_key($credentialMode);
+        }
+
+        wp_safe_redirect(add_query_arg($args, admin_url('admin.php')));
+        exit;
+    }
+
+    private static function requireAdmin(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(
+                esc_html__('You are not allowed to manage DNSBL Tools authorization.', 'tornevall-networks-dnsbl-implementation'),
+                '',
+                ['response' => 403]
+            );
+        }
+    }
+}

--- a/tornevall-wp-dnsbl.php
+++ b/tornevall-wp-dnsbl.php
@@ -33,6 +33,7 @@ foreach ([
     'includes/class-dnsbl-write-queue.php',
     'includes/class-dnsbl-integration.php',
     'includes/class-dnsbl-managed-tools-token.php',
+    'includes/class-dnsbl-tools-pairing.php',
     'includes/class-dnsbl-telemetry.php',
     'includes/class-dnsbl-woocommerce.php',
     'includes/dnsbl-utils.php',
@@ -55,5 +56,6 @@ register_uninstall_hook(TORNEVALL_DNSBL_PLUGIN_FILE, 'tornevall_wp_dnsbl_uninsta
 tornevall_dnsbl_register_hooks();
 \Tornevall\Networks\DNSBL\Integration::registerHooks();
 \Tornevall\Networks\DNSBL\ManagedToolsToken::registerHooks();
+\Tornevall\Networks\DNSBL\ToolsPairing::registerHooks();
 \Tornevall\Networks\DNSBL\Telemetry::registerHooks();
 \Tornevall\Networks\DNSBL\WooCommerce::registerHooks();

--- a/tornevall-wp-dnsbl.php
+++ b/tornevall-wp-dnsbl.php
@@ -32,6 +32,7 @@ foreach ([
     'includes/class-dnsbl-api-client.php',
     'includes/class-dnsbl-write-queue.php',
     'includes/class-dnsbl-integration.php',
+    'includes/class-dnsbl-managed-tools-token.php',
     'includes/class-dnsbl-telemetry.php',
     'includes/class-dnsbl-woocommerce.php',
     'includes/dnsbl-utils.php',
@@ -53,5 +54,6 @@ register_uninstall_hook(TORNEVALL_DNSBL_PLUGIN_FILE, 'tornevall_wp_dnsbl_uninsta
 
 tornevall_dnsbl_register_hooks();
 \Tornevall\Networks\DNSBL\Integration::registerHooks();
+\Tornevall\Networks\DNSBL\ManagedToolsToken::registerHooks();
 \Tornevall\Networks\DNSBL\Telemetry::registerHooks();
 \Tornevall\Networks\DNSBL\WooCommerce::registerHooks();


### PR DESCRIPTION
Closes #56.

Related:
- https://github.com/Tornevall/toolsApi/pull/505
- https://github.com/Tornevall/tornevall-tools-for-wordpress/pull/21

## Summary

- adds direct device-style authorization from the DNSBL settings page to Tornevall Tools
- requests only DNSBL access and uses the logged-in Tools session for explicit approval
- lets the Tools approval screen select an existing active DNSBL token
- defaults to rotating/reusing the selected non-admin token so the old secret is invalidated and the new value is installed directly into `tornevall_dnsbl_write_token`
- supports the Tools-side alternative of creating a separate site token
- never installs an admin DNSBL token directly; Tools returns a non-admin copy when admin permissions are selected
- keeps the raw device code in a short-lived per-admin WordPress transient and performs credential exchange server-to-server once
- validates the Tools authorization host and validates callback state, WordPress nonce and pairing state before exchange
- never displays or logs token/device-code values
- shows safe connection/result notices and credential-mode-specific success wording
- keeps the optional `tornevall_dnsbl_managed_api_token` bridge so Tornevall Tools for WordPress can still provide a server-side fallback credential
- preserves explicit DNSBL plugin token priority

A separate OAuth client secret is not required. Tools authenticates the user through the normal web session and authorizes the high-entropy one-time device exchange explicitly.