### PR TITLE
Fix #30: hide deprecated DNSBL bit 1 trigger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+This file defines repository-local guidance for Tornevall Networks DNSBL WordPress development.
+
+## Scope
+
+This repository contains the standalone Tornevall Networks DNSBL WordPress plugin. Keep DNSBL/FraudBL behavior here rather than duplicating it in Tornevall Tools for WordPress.
+
+## Branch model
+
+Read `.github/BRANCHING.md` before branch or release work.
+
+- `3.1` is the current stable maintenance/development line.
+- `master` mirrors the current stable line.
+- `3.2` is downstream from `3.1` and contains the 3.2.0 WooCommerce/fraud work.
+- Stable changes that apply to both lines should land in `3.1` first and then flow to `master` and `3.2`.
+- Do not create release tags merely because branches are synchronized.
+- Never force-push or silently resolve forward-sync conflicts.
+
+## Security
+
+- Sanitize input and escape output.
+- Keep tokens and secrets server-side.
+- Protect state-changing admin actions with capability checks and nonces.
+- Do not send credentials in URLs, browser-visible markup, logs, tests, screenshots or documentation examples.
+
+## Testing
+
+Material changes require relevant tests and CI coverage where practical.
+
+- Run PHP syntax checks for changed PHP files.
+- Keep WordPress Plugin Check coverage intact.
+- Add regression tests for behavior changes whenever practical.
+
+## Documentation
+
+Behavior changes should update the relevant repository documentation, including `README.md`, `readme.txt`, `CHANGELOG.md` and files under `docs/` when applicable.
+
+Every development change should have a linked issue and pull request. Reuse existing issues and PRs when they already track the work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to the DNSBL plugin should be documented in this file.
 - Explicit DNSBL plugin token settings keep priority over managed credentials.
 - Managed credentials are resolved server-side only and are not rendered into browser markup, JavaScript, diagnostics or logs by the bridge.
 
+### Fixed
+- Deprecated DNSBL bit 1 (`FREE_SLOT_1_PREVIOUSLY_REPORTED`) is no longer offered as a WordPress trigger flag, and legacy saved selections are normalized away without changing `IP_CONFIRMED` on bit 2 or the internal legacy response map.
+
 ## 3.1.6 - 2026-08-19
 
 ### Added

--- a/docs/deprecated-dnsbl-bit-1.md
+++ b/docs/deprecated-dnsbl-bit-1.md
@@ -1,0 +1,13 @@
+# Deprecated DNSBL bit 1
+
+DNSBL bit value `1` is retained only for decoding legacy DNSBL responses and historical data. Its canonical legacy name is `FREE_SLOT_1_PREVIOUSLY_REPORTED`.
+
+The active verified-proxy flag remains `IP_CONFIRMED` on bit value `2`. Bit 1 must not be repurposed as another verified-proxy trigger.
+
+## WordPress trigger settings
+
+The WordPress plugin does not expose `FREE_SLOT_1_PREVIOUSLY_REPORTED [1]` in the "Trigger on blacklist flags" selector.
+
+Existing installations that still have the deprecated flag stored in `tornevall_dnsbl_filter_types` are normalized automatically. The deprecated value is removed while all active selected flags are preserved.
+
+The internal DNSBL flag map still retains bit value 1 so legacy response masks can continue to be decoded without changing the meaning or value of the active flags.

--- a/includes/class-dnsbl-deprecated-flag-guard.php
+++ b/includes/class-dnsbl-deprecated-flag-guard.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tornevall\Networks\DNSBL;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class DeprecatedFlagGuard
+{
+    public const DEPRECATED_TRIGGER_FLAG = 'FREE_SLOT_1_PREVIOUSLY_REPORTED';
+
+    public static function registerHooks(): void
+    {
+        add_action('init', [self::class, 'normalizeStoredSelection'], 1);
+        add_filter('pre_update_option_tornevall_dnsbl_filter_types', [self::class, 'normalizeForStorage'], 10, 3);
+        add_action('admin_footer', [self::class, 'removeDeprecatedAdminOption']);
+    }
+
+    public static function normalizeSelection($selected): array
+    {
+        $normalized = Plugin::normalizeSelectedFlags($selected);
+
+        return array_values(array_filter(
+            $normalized,
+            static function ($flagName): bool {
+                return $flagName !== self::DEPRECATED_TRIGGER_FLAG;
+            }
+        ));
+    }
+
+    public static function normalizeForStorage($newValue, $oldValue = null, $option = null): array
+    {
+        return self::normalizeSelection($newValue);
+    }
+
+    public static function normalizeStoredSelection(): void
+    {
+        $selected = get_option('tornevall_dnsbl_filter_types');
+        $normalized = self::normalizeSelection($selected);
+
+        if (!is_array($selected) || $selected !== $normalized) {
+            update_option('tornevall_dnsbl_filter_types', $normalized);
+        }
+    }
+
+    public static function removeDeprecatedAdminOption(): void
+    {
+        if (!is_admin()) {
+            return;
+        }
+
+        ?>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                var selector = document.getElementById('tornevall_dnsbl_filter_types');
+                if (!selector) {
+                    return;
+                }
+
+                var deprecated = selector.querySelector('option[value="<?php echo esc_js(self::DEPRECATED_TRIGGER_FLAG); ?>"]');
+                if (deprecated) {
+                    deprecated.remove();
+                }
+            });
+        </script>
+        <?php
+    }
+}

--- a/tests/runtime-deprecated-flag-guard.php
+++ b/tests/runtime-deprecated-flag-guard.php
@@ -1,0 +1,78 @@
+<?php
+
+define('ABSPATH', __DIR__ . '/');
+
+namespace Tornevall\Networks\DNSBL {
+    class Plugin
+    {
+        public static function normalizeSelectedFlags($selected): array
+        {
+            if (!is_array($selected)) {
+                return [];
+            }
+
+            $active = [
+                'FREE_SLOT_1_PREVIOUSLY_REPORTED',
+                'IP_CONFIRMED',
+                'IP_PHISHING',
+                'IP_FRAUDCOMMERCE',
+                'IP_MAILSERVER_SPAM',
+                'IP_SECOND_EXIT',
+                'IP_ABUSE_NO_SMTP',
+                'IP_ANONYMOUS',
+            ];
+
+            return array_values(array_unique(array_values(array_filter(
+                $selected,
+                static function ($flag) use ($active): bool {
+                    return is_string($flag) && in_array($flag, $active, true);
+                }
+            ))));
+        }
+    }
+}
+
+namespace {
+    require_once dirname(__DIR__) . '/includes/class-dnsbl-deprecated-flag-guard.php';
+
+    use Tornevall\Networks\DNSBL\DeprecatedFlagGuard;
+
+    $selection = DeprecatedFlagGuard::normalizeSelection([
+        'FREE_SLOT_1_PREVIOUSLY_REPORTED',
+        'IP_CONFIRMED',
+        'IP_FRAUDCOMMERCE',
+        'IP_ABUSE_NO_SMTP',
+        'IP_CONFIRMED',
+    ]);
+
+    $expected = [
+        'IP_CONFIRMED',
+        'IP_FRAUDCOMMERCE',
+        'IP_ABUSE_NO_SMTP',
+    ];
+
+    if ($selection !== $expected) {
+        fwrite(STDERR, 'Deprecated flag normalization failed.' . PHP_EOL);
+        exit(1);
+    }
+
+    $saved = DeprecatedFlagGuard::normalizeForStorage([
+        'FREE_SLOT_1_PREVIOUSLY_REPORTED',
+        'IP_SECOND_EXIT',
+        'IP_ANONYMOUS',
+    ]);
+
+    if ($saved !== ['IP_SECOND_EXIT', 'IP_ANONYMOUS']) {
+        fwrite(STDERR, 'Saved trigger normalization failed.' . PHP_EOL);
+        exit(1);
+    }
+
+    if (in_array('FREE_SLOT_1_PREVIOUSLY_REPORTED', DeprecatedFlagGuard::normalizeSelection([
+        'FREE_SLOT_1_PREVIOUSLY_REPORTED',
+    ]), true)) {
+        fwrite(STDERR, 'Deprecated bit 1 remained selectable.' . PHP_EOL);
+        exit(1);
+    }
+
+    echo 'Deprecated flag guard checks passed.' . PHP_EOL;
+}

--- a/tests/runtime-deprecated-flag-guard.php
+++ b/tests/runtime-deprecated-flag-guard.php
@@ -1,7 +1,5 @@
 <?php
 
-define('ABSPATH', __DIR__ . '/');
-
 namespace Tornevall\Networks\DNSBL {
     class Plugin
     {
@@ -33,6 +31,8 @@ namespace Tornevall\Networks\DNSBL {
 }
 
 namespace {
+    define('ABSPATH', __DIR__ . '/');
+
     require_once dirname(__DIR__) . '/includes/class-dnsbl-deprecated-flag-guard.php';
 
     use Tornevall\Networks\DNSBL\DeprecatedFlagGuard;

--- a/tornevall-wp-dnsbl.php
+++ b/tornevall-wp-dnsbl.php
@@ -36,6 +36,7 @@ foreach ([
     'includes/class-dnsbl-tools-pairing.php',
     'includes/class-dnsbl-telemetry.php',
     'includes/class-dnsbl-woocommerce.php',
+    'includes/class-dnsbl-deprecated-flag-guard.php',
     'includes/dnsbl-utils.php',
     'includes/dnsbl-migrations.php',
     'includes/dnsbl-bootstrap.php',
@@ -59,3 +60,4 @@ tornevall_dnsbl_register_hooks();
 \Tornevall\Networks\DNSBL\ToolsPairing::registerHooks();
 \Tornevall\Networks\DNSBL\Telemetry::registerHooks();
 \Tornevall\Networks\DNSBL\WooCommerce::registerHooks();
+\Tornevall\Networks\DNSBL\DeprecatedFlagGuard::registerHooks();


### PR DESCRIPTION
## Summary
- hide `FREE_SLOT_1_PREVIOUSLY_REPORTED` (bit 1) from the WordPress trigger selector
- normalize legacy saved trigger selections on init and on save
- keep the internal legacy bit map intact and leave `IP_CONFIRMED` on bit 2 unchanged
- add focused regression coverage and documentation
- add repository-local `AGENTS.md` guidance required for development work

## Verification
- PHP syntax check: `includes/class-dnsbl-deprecated-flag-guard.php`
- PHP syntax check: `tests/runtime-deprecated-flag-guard.php`
- focused runtime regression: `tests/runtime-deprecated-flag-guard.php` passed
- branch comparison against `3.1`: ahead only, behind by 0

Closes #30
